### PR TITLE
Fix: default MAX_DECISIONS=40000 prevents bouncer overload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,16 +11,20 @@ services:
     environment:
       # CrowdSec container name (must be accessible via Docker socket)
       - CROWDSEC_CONTAINER=crowdsec
-      
+
       # How long decisions last (run script daily to refresh)
       - DECISION_DURATION=24h
-      
+
+      # Max total decisions — prevents bouncer overload on embedded devices (#21)
+      # UDM SE/Pro: 50000 | UDR: 15000 | USG: 8000 | Linux server: 0 (unlimited)
+      - MAX_DECISIONS=40000
+
       # Logging (DEBUG, INFO, WARN, ERROR)
       - LOG_LEVEL=INFO
-      
+
       # Timezone
       - TZ=America/New_York
-      
+
       # Anonymous telemetry (enabled by default, set to false to disable)
       - TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
     


### PR DESCRIPTION
## Summary

- Sets `MAX_DECISIONS=40000` as the default (was unlimited), preventing the 120K+ decision import that crashes UniFi Network app
- Adds `MAX_DECISIONS=0` / `unlimited` option to explicitly disable the cap for Linux server bouncers
- Logs the active `MAX_DECISIONS` value at startup so users always know what limit applies
- Warns when projected total exceeds 65536 (default ipset maxelem) if the cap is disabled
- Documents per-device recommended values (UDM SE: 50000, UDR: 15000, USG: 8000)
- Documents `BOUNCER_SSH` and `DEVICE_MEM_FLOOR` in the Configuration table
- Adds comprehensive "Firewall Bouncer Limits / ipset Sizing" README section with device table, config examples, two-layer protection, and crash recovery steps
- Adds prominent warning callout for embedded device users near the top of README
- Includes `MAX_DECISIONS=40000` in the example `docker-compose.yml`

## Root Cause

When all 36 feeds import ~123K decisions into CrowdSec LAPI, the UniFi firewall bouncer pushes all entries into a single `crowdsec-blacklists` ipset. This exceeds the UDM's ipset maxelem (65K default, raised to 120K on UDM SE), causing the Network application to crash. The Network app does not gracefully shed excess entries — it goes offline entirely.

## What Changed

### `import.sh`
- Version bump to 2.1.1
- `MAX_DECISIONS` default changed from empty (unlimited) to `40000`
- Accepts `0` or `unlimited` to explicitly disable
- Startup banner shows active cap or warns about unlimited mode
- Guardrail logic warns when exceeding 65536 without a cap

### `README.md`
- Warning callout for embedded device users
- New "Firewall Bouncer Limits / ipset Sizing" section with per-device table
- Configuration examples for UDM SE, UDR, Linux
- Two-layer protection documentation (MAX_DECISIONS + BOUNCER_SSH)
- Crash recovery procedure
- `MAX_DECISIONS`, `BOUNCER_SSH`, `DEVICE_MEM_FLOOR` added to config table
- Roadmap updated

### `docker-compose.yml`
- Added `MAX_DECISIONS=40000` with per-device guidance comments

Closes #21

## Test plan

- [ ] Run with default config — verify `MAX_DECISIONS=40000` logged at startup
- [ ] Run with `MAX_DECISIONS=0` — verify "UNLIMITED" warning logged
- [ ] Run with `MAX_DECISIONS=50000` — verify cap shown
- [ ] Run with `DRY_RUN=true` to verify cap logic without actual import
- [ ] Verify bash syntax: `bash -n import.sh`
- [ ] Verify existing `BOUNCER_SSH` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)