### PR TITLE
v2.2.0: implement allow-lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ curl -sL https://raw.githubusercontent.com/wolffcatskyy/crowdsec-blocklist-impor
 | `DRY_RUN` | `false` | Preview mode - shows what would be imported without making changes |
 | `ENABLE_<SOURCE>` | `true` | Disable individual sources: `ENABLE_IPSUM=false`, `ENABLE_TOR_EXIT_NODES=false`, etc. |
 | `CUSTOM_BLOCKLISTS` | _(empty)_ | Comma-separated URLs of additional blocklists to import |
+| `ALLOWLIST_URL` | _(empty)_ | URL to fetch allow-list from (one IP/CIDR per line, # for comments) |
+| `ALLOWLIST_FILE` | _(empty)_ | Local file path containing allow-list (one IP/CIDR per line, # for comments) |
+| `ALLOWLIST` | _(empty)_ | Inline allow-list as comma-separated values (e.g. "1.1.1.1,8.8.8.8,192.168.1.0/24") |
 
 > **Note:** Container names are case-sensitive! If your container is named `Crowdsec` (capital C), set `CROWDSEC_CONTAINER=Crowdsec`.
 
@@ -279,6 +282,14 @@ Source name mapping: `IPsum` → `ENABLE_IPSUM`, `Spamhaus DROP` → `ENABLE_SPA
 
 ```bash
 -e CUSTOM_BLOCKLISTS="https://example.com/my-blocklist.txt,https://example.com/another.txt"
+```
+
+### Allow-lists (v2.2.0)
+
+Any matching entries are removed from the block-lists.
+
+```bash
+-e ALLOWLIST="140.82.121.3,140.82.121.4,140.82.121.5"
 ```
 
 ## Security


### PR DESCRIPTION
closes #26

```
févr. 07 01:05:00 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:00] [DEBUG] Loading allow-list from file: /var/lib/crowdsec/allow-list.txt
févr. 07 01:05:00 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:00] [DEBUG] Loaded 1 entries from ALLOWLIST_FILE
févr. 07 01:05:00 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:00] [DEBUG] Loading allow-list from ALLOWLIST variable
févr. 07 01:05:00 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:00] [DEBUG] Loaded 1 entries from ALLOWLIST
févr. 07 01:05:00 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:00] [INFO] Allow-list loaded: 2 unique entries
[...]

févr. 07 01:05:12 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:12] [INFO] Combining and deduplicating...
févr. 07 01:05:12 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:12] [INFO] Applying allow-list...
févr. 07 01:05:12 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:12] [INFO] Allow-list filtered 2 entries from filtered_private.txt
févr. 07 01:05:12 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:12] [INFO] Allow-list removed 2 IPs
févr. 07 01:05:12 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:12] [INFO] Checking existing CrowdSec decisions...
févr. 07 01:05:14 aero-server crowdsec-blocklist-import[315243]: [2026-02-07 00:05:14] [DEBUG] Found 124044 existing decisions
```

Disclaimer: most of the code was AI generated by claude - but I have feeling you won't mind.

I tested it & fixed it appropriately.