### PR TITLE
feat: Add CROWDSEC_MACHINE_PASSWORD_FILE for Docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,49 @@ networks:
     external: true
 ```
 
+### Docker Compose with Secrets
+
+For production deployments, use Docker secrets instead of environment variables:
+
+```yaml
+secrets:
+  crowdsec_lapi_key:
+    file: ./secrets/crowdsec_lapi_key.txt
+  crowdsec_machine_password:
+    file: ./secrets/crowdsec_machine_password.txt
+
+services:
+  blocklist-import:
+    image: ghcr.io/wolffcatskyy/crowdsec-blocklist-import-python:latest
+    container_name: blocklist-import
+    restart: "no"
+    networks:
+      - crowdsec
+    secrets:
+      - crowdsec_lapi_key
+      - crowdsec_machine_password
+    environment:
+      - CROWDSEC_LAPI_URL=http://crowdsec:8080
+      - CROWDSEC_LAPI_KEY_FILE=/run/secrets/crowdsec_lapi_key
+      - CROWDSEC_MACHINE_ID=blocklist-import
+      - CROWDSEC_MACHINE_PASSWORD_FILE=/run/secrets/crowdsec_machine_password
+      - DECISION_DURATION=24h
+      - TZ=America/New_York
+
+networks:
+  crowdsec:
+    external: true
+```
+
+Create the secrets files:
+
+```bash
+mkdir -p ./secrets
+echo "your-bouncer-api-key" > ./secrets/crowdsec_lapi_key.txt
+echo "your-machine-password" > ./secrets/crowdsec_machine_password.txt
+chmod 600 ./secrets/*.txt
+```
+
 ### Direct Execution
 
 ```bash


### PR DESCRIPTION
## Summary

- Simplifies `read_secret_file()` to follow the standard Docker secrets pattern (read file, strip whitespace)
- `_FILE` env vars now take precedence over direct values (e.g., `CROWDSEC_MACHINE_PASSWORD_FILE` overrides `CROWDSEC_MACHINE_PASSWORD`)
- Adds Docker Compose with Secrets example to README showing how to use secrets files mounted at `/run/secrets/`

## Test plan

- [ ] Verify secrets file reading works with simple text files containing just the secret value
- [ ] Test with Docker secrets mounted at `/run/secrets/<name>`
- [ ] Confirm `_FILE` vars take precedence when both are set

Closes #19.

Generated with [Claude Code](https://claude.com/claude-code)