### PR TITLE
feat: Add --version and --help CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ python blocklist_import.py --dry-run
 
 ## CLI Options
 
+### Bash Script (import.sh)
+
+```text
+Usage: import.sh [OPTIONS]
+
+Options:
+  --help, -h          Show help message and exit
+  --version, -v       Show version number and exit
+  --list-sources      List all available blocklist sources with their toggle variables
+  --dry-run           Run without making changes (same as DRY_RUN=true)
+
+Examples:
+  ./import.sh --version           # Show version
+  ./import.sh --help              # Show help
+  ./import.sh --list-sources      # List all 30 blocklist sources
+  ./import.sh --dry-run           # Preview what would be imported
+  ENABLE_TOR_EXIT_NODES=false ./import.sh  # Run with Tor sources disabled
+```
+
+### Python Script (blocklist_import.py)
+
 ```text
 usage: blocklist_import.py [-h] [-v] [-n] [-d] [--lapi-url LAPI_URL]
                            [--lapi-key LAPI_KEY] [--duration DURATION]


### PR DESCRIPTION
## Summary

- Adds `--version`/`-v` flag to show version and exit
- Adds `--help`/`-h` flag to show comprehensive usage info
- Adds `--list-sources` flag to display all 30 blocklist sources with their `ENABLE_*` variable names
- Adds `--dry-run` flag as a CLI alternative to `DRY_RUN=true` env var

## Implementation

Uses a simple bash `case` statement before `main "$@"` to handle CLI arguments. No external dependencies required.

## Test plan

- [x] `./import.sh --version` prints version and exits (exit code 0)
- [x] `./import.sh -v` same as `--version`
- [x] `./import.sh --help` prints usage info with all env vars and exits
- [x] `./import.sh -h` same as `--help`
- [x] `./import.sh --list-sources` prints all 30 sources with their `ENABLE_*` var names
- [x] `./import.sh --dry-run` sets `DRY_RUN=true` and runs normally
- [x] Running with no arguments works exactly as before (backward compatible)
- [x] Help text includes the GitHub repo URL
- [x] `ENABLE_*=false` shows as "DISABLED" in `--list-sources` output

Closes #13

---
Generated with [Claude Code](https://claude.com/claude-code)