### PR TITLE
feat: Add Prometheus metrics endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # image: ghcr.io/wolffcatskyy/crowdsec-blocklist-import:latest
     container_name: crowdsec-blocklist-import
     restart: "no"  # Run once and exit
-    
+
     environment:
       # CrowdSec container name (must be accessible via Docker socket)
       - CROWDSEC_CONTAINER=crowdsec
@@ -27,7 +27,15 @@ services:
 
       # Anonymous telemetry (enabled by default, set to false to disable)
       - TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
-    
+
+      # Prometheus metrics (enabled by default on port 9102)
+      - METRICS_ENABLED=${METRICS_ENABLED:-true}
+      - METRICS_PORT=${METRICS_PORT:-9102}
+
+    ports:
+      # Prometheus metrics endpoint
+      - "9102:9102"
+
     volumes:
       # Docker socket for accessing CrowdSec container
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ requests>=2.28.0,<3.0.0
 
 # Environment variable loading
 python-dotenv>=1.0.0,<2.0.0
+
+# Prometheus metrics (optional but recommended)
+prometheus-client>=0.17.0,<1.0.0


### PR DESCRIPTION
## Summary

- Adds a built-in Prometheus metrics endpoint for monitoring blocklist imports
- Exposes metrics on port 9102 (configurable via `METRICS_PORT` env var)
- Gracefully degrades if `prometheus-client` is not installed

## Metrics Exposed

| Metric | Type | Description |
|--------|------|-------------|
| `blocklist_import_total_ips` | Gauge | Total IPs imported in last run |
| `blocklist_import_last_run_timestamp` | Gauge | Unix timestamp of last run |
| `blocklist_import_sources_enabled` | Gauge | Number of enabled sources |
| `blocklist_import_sources_successful` | Gauge | Sources successfully fetched |
| `blocklist_import_sources_failed` | Gauge | Sources that failed to fetch |
| `blocklist_import_existing_decisions` | Gauge | Existing CrowdSec decisions found |
| `blocklist_import_new_ips` | Gauge | New unique IPs added |
| `blocklist_import_errors_total` | Counter | Errors by type (fetch/parse/encoding/import) |
| `blocklist_import_duration_seconds` | Histogram | Import duration |

## Configuration

Environment variables:
- `METRICS_ENABLED` - Enable/disable metrics (default: `true`)
- `METRICS_PORT` - Port for metrics endpoint (default: `9102`)

CLI flags:
- `--metrics-port PORT` - Override metrics port
- `--no-metrics` - Disable metrics endpoint

## Test Plan

- [ ] Run with `METRICS_ENABLED=true` and verify metrics at `http://localhost:9102/metrics`
- [ ] Run with `METRICS_ENABLED=false` and verify no metrics server starts
- [ ] Run without `prometheus-client` installed and verify graceful warning
- [ ] Verify metrics update after import completes
- [ ] Test Docker Compose with exposed port

Closes #6

---
Generated with [Claude Code](https://claude.ai/code)