### PR TITLE
feat: CIDR-aware allowlist matching and ALLOWLIST_GITHUB provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,19 @@ DECISION_ORIGIN=blocklist-import
 # Decision scenario (for filtering)
 DECISION_SCENARIO=external/blocklist
 
-# Allow Github IPs
+# Allowlist - comma-separated IPs and/or CIDR ranges to exclude from bans
+# Supports both individual IPs and CIDR notation for range matching
+# Examples:
+#   ALLOWLIST=1.2.3.4,5.6.7.8                    # Individual IPs
+#   ALLOWLIST=140.82.112.0/20,185.199.108.0/22   # CIDR ranges
+#   ALLOWLIST=1.2.3.4,140.82.112.0/20            # Mixed
 ALLOWLIST=140.82.121.3,140.82.121.4
+
+# Provider allowlists - auto-fetch IP ranges from well-known providers
+# ALLOWLIST_GITHUB: Fetches GitHub's IP ranges from https://api.github.com/meta
+#   Covers: git, web, api, hooks, and actions IP ranges
+#   Falls back to hardcoded ranges if API is unreachable
+ALLOWLIST_GITHUB=false
 
 LOG_TIMESTAMPS=true
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,23 +2,26 @@
 
 This document outlines the planned features and improvements for `crowdsec-blocklist-import`. We welcome community contributions to any of these items.
 
-**Current Version:** v3.3.2
+**Current Version:** v3.4.0
 **GitHub Stars:** 167
 
 ---
 
-## v3.4.0 — Prometheus Push Gateway Fix
+## v3.4.0 — CIDR Allowlists & Prometheus Push Gateway
 
-**Status:** In Progress (PR #35)
+**Status:** Released
 **Target:** Q1 2026
 
-The current Prometheus metrics implementation uses a pull model, which does not work well for short-lived containers that run on a schedule. PR #35 refactors this to use Prometheus Push Gateway instead.
+Adds CIDR-aware allowlist matching and provider allowlists (GitHub), plus Prometheus Push Gateway support.
 
 ### Changes
-- [ ] Switch from Prometheus scrape endpoint to Push Gateway
-- [ ] Add `PUSHGATEWAY_URL` environment variable
-- [ ] Include Grafana dashboard JSON for easy monitoring setup
-- [ ] Fix credential file reading regression from v3.3.0
+- [x] Switch from Prometheus scrape endpoint to Push Gateway (PR #35)
+- [x] Add `PUSHGATEWAY_URL` environment variable
+- [x] Include Grafana dashboard JSON for easy monitoring setup
+- [x] Fix credential file reading regression from v3.3.0
+- [x] CIDR-aware allowlist matching (`ALLOWLIST="140.82.112.0/20"`) (#38)
+- [x] `ALLOWLIST_GITHUB=true` provider allowlist - auto-fetches GitHub IP ranges
+- [x] Backwards-compatible: individual IPs in ALLOWLIST still work
 
 ---
 
@@ -141,6 +144,7 @@ We use **AI-Ready Issues** — every issue includes implementation details, acce
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v3.4.0 | 2026-02-20 | CIDR allowlists, ALLOWLIST_GITHUB provider, Prometheus push gateway |
 | v3.3.2 | 2026-02-17 | Allowlist parsing fix |
 | v3.3.1 | 2026-02-17 | CrowdSec credential file fix |
 | v3.3.0 | 2026-02-16 | Docker secrets, allowlists, CLI enhancements, Prometheus metrics, env validation |


### PR DESCRIPTION
## Summary

- Adds CIDR-aware matching to the `ALLOWLIST` feature so `ALLOWLIST="140.82.112.0/20,185.199.108.0/22"` correctly matches any IP within those ranges (not just exact strings)
- Adds `ALLOWLIST_GITHUB=true` environment variable that auto-fetches GitHub's IP ranges from their meta API and adds them to the allowlist
- Bumps version to 3.4.0

## Problem

Users running gateway/reverse proxy servers with CrowdSec nftables forward chain bouncer (hooking into both `input` and `forward`) get legitimate GitHub traffic blocked because GitHub IPs appear in 18+ blocklist sources (IPsum, CI Army, AbuseIPDB, Binary Defense, Firehol, etc.). The existing `ALLOWLIST` feature only does exact string matching, so users would need to manually list every single GitHub IP address.

As reported by @l4rm4nd in #38, a diagnostic script found **5,778 GitHub IP ranges** hit across 29 blocklist sources.

## Implementation

### `Allowlist` class (`blocklist_import.py`)
- Individual IPs stored in a `set()` for O(1) exact lookup (fast path)
- CIDR networks stored as `ipaddress.IPv4Network`/`IPv6Network` objects
- `contains(ip_str)` method checks:
  - Exact string match against IP set
  - For single IPs: containment check against all allowlisted networks
  - For CIDR ranges from blocklists: overlap check against allowlisted networks
- `fetch_github_ranges()` fetches from `https://api.github.com/meta` (sections: git, web, api, hooks, actions) with fallback to hardcoded ranges

### `build_allowlist()` factory function
- Processes `ALLOWLIST` env var entries (backwards compatible with individual IPs)
- Fetches GitHub ranges if `ALLOWLIST_GITHUB=true`
- Logs summary of loaded entries

### Usage
```bash
# CIDR ranges in allowlist (new)
ALLOWLIST="140.82.112.0/20,185.199.108.0/22"

# Auto-fetch GitHub IP ranges (new)
ALLOWLIST_GITHUB=true

# Mixed (backwards compatible)
ALLOWLIST="1.2.3.4,140.82.112.0/20"
```

## Test plan

- [x] Python syntax validation passes
- [x] Unit tests for `Allowlist` class: exact IP match, CIDR containment, CIDR overlap, IPv6 support, backwards compatibility
- [ ] Integration test with `--dry-run` and `ALLOWLIST` containing CIDRs
- [ ] Integration test with `ALLOWLIST_GITHUB=true` and `--dry-run`
- [ ] Verify GitHub meta API fetch works and falls back gracefully on network error

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)