### PR TITLE
ci: fix Docker image version tagging on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,9 +3,10 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -23,9 +24,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify version matches tag
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'release'
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"
           CODE_VERSION=$(python3 -c "
           import re
           with open('blocklist_import.py') as f:
@@ -63,7 +65,8 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

Fixes #41 - Docker release tag 3.3.2 downloads 3.3.0.

The root cause was two-fold:

1. **`__version__` not bumped in code**: When releases v3.3.1 and v3.3.2 were created, the `__version__` string in `blocklist_import.py` remained `"3.3.0"`. The Docker images were correctly built and tagged (`:3.3.2` exists with different content than `:3.3.0`), but the application self-reports as v3.3.0 because that string was never updated.

2. **Workflow triggered on `push:tags` instead of `release:published`**: The `push:tags` trigger fires on any tag push, which can happen before the code is ready or without proper version bumps. The `release:published` trigger is the standard approach — it fires only when a proper GitHub Release is created, making it the right time to build and tag Docker images.

### Changes

- **Replace `push:tags` trigger with `release:published`** — Docker version-tagged builds now only happen when a GitHub Release is published, which is the correct semantic trigger
- **Version verification uses release event payload** — `github.event.release.tag_name` is more reliable than parsing `github.ref` for release builds
- **`latest` tag only on releases** — Changed from `enable={{is_default_branch}}` (which could apply `latest` during branch pushes) to `enable=${{ github.event_name == 'release' }}` so `latest` only updates when a release is published
- **Added major version tag** — Users can now pin to `:3` (major version) in addition to `:3.3.2` (exact), `:3.3` (minor), and `:latest`
- Branch pushes to `main` still build and tag with `:main` for development/testing

### How it works now

When a GitHub Release (e.g., `v3.4.0`) is published:
1. Version guard verifies `__version__` in `blocklist_import.py` matches the tag
2. If mismatch, build **fails fast** before pushing any images
3. If match, images are built and tagged: `:3.4.0`, `:3.4`, `:3`, `:latest`

### Test plan

- [ ] Merge this PR
- [ ] Create a test release (e.g., v3.4.0) with matching `__version__`
- [ ] Verify workflow runs on `release` event
- [ ] Verify Docker image tags `:3.4.0`, `:3.4`, `:3`, `:latest` are all created
- [ ] Verify `docker run ghcr.io/wolffcatskyy/crowdsec-blocklist-import:3.4.0 --version` shows `3.4.0`

---

*This PR was generated by Claude AI assisting the maintainer.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>