### PR TITLE
Fix freeze in case of 429 error

### DIFF
--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -1253,6 +1253,7 @@ def create_http_session(max_retries: int = 3) -> requests.Session:
 
     retry_strategy = Retry(
         total=max_retries,
+        respect_retry_after_header=False,
         backoff_factor=1,  # 1s, 2s, 4s...
         status_forcelist=[429, 500, 502, 503, 504],
         allowed_methods=["HEAD", "GET", "POST", "DELETE"],


### PR DESCRIPTION
The recently added Abuse IP DB API endpoint allows 5 queries per day.

After this limit has been reached, it sends a 429 error with a header specifying the time needed to wait until rate-limiting is lifted.

The current implementation has a retry strategy that respects this header. This results in the script blocking its execution for potentially hours on end, thus blocking updates of all other sources.

As this script is meant to be run regularly, let's ignore this header so that a 429 skips the source instead of waiting after it.