### PR TITLE
`v1/decisions`: remove `?limit=0` query parameter

### DIFF
--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -1537,9 +1537,8 @@ class CrowdSecLAPI:
         existing: Set[str] = set()
 
         try:
-            # Fetch all decisions at once using limit=0 (standard CrowdSec approach)
             response = self.session.get(
-                f"{self.base_url}/v1/decisions?limit=0",
+                f"{self.base_url}/v1/decisions",
                 headers=self.bouncer_headers,
                 timeout=60,
             )


### PR DESCRIPTION
This parameter was recently added and results in `response = None`. Therefore bloclkist IPs are always considered new, which causes very long import times on each run (3mn vs 20sec), which I detected thanks to the Grafana dashboard.

Please don't generate any new release yet, after this is merged. I still have other important changes to submit.