### PR TITLE
feat: add LAPI TLS client support (#78)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,16 @@ CROWDSEC_MACHINE_ID=blocklist-import
 CROWDSEC_MACHINE_PASSWORD=YourSecurePassword
 # or: CROWDSEC_MACHINE_PASSWORD_FILE=local_api_credentials_file_path
 
+# Optional: trust bundle used to verify the HTTPS certificate served by LAPI.
+# This does not authenticate the importer to LAPI.
+# CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
+
+# Optional: LAPI client certificate authentication.
+# CERT_PATH and KEY_PATH must be set together. They authenticate this importer
+# to LAPI with mTLS instead of CROWDSEC_LAPI_KEY.
+# CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
+# CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+
 # =============================================================================
 # Decision Settings
 # =============================================================================
@@ -151,4 +161,3 @@ ENABLE_CYBERCRIME_TRACKER=true
 ENABLE_MONTY_SECURITY_C2=true
 
 ENABLE_VXVAULT=true
-

--- a/.env.example
+++ b/.env.example
@@ -24,11 +24,15 @@ CROWDSEC_MACHINE_PASSWORD=YourSecurePassword
 # This does not authenticate the importer to LAPI.
 # CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
 
-# Optional: LAPI client certificate authentication.
-# CERT_PATH and KEY_PATH must be set together. They authenticate this importer
-# to LAPI with mTLS instead of CROWDSEC_LAPI_KEY.
-# CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
-# CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+# Optional: agent client certificate for JWT/write authentication.
+# AGENT_CERT_PATH and AGENT_KEY_PATH must be set together.
+# CROWDSEC_LAPI_AGENT_CERT_PATH=/certs/blocklist-import-agent.pem
+# CROWDSEC_LAPI_AGENT_KEY_PATH=/certs/blocklist-import-agent-key.pem
+
+# Optional: bouncer client certificate for reading existing decisions.
+# BOUNCER_CERT_PATH and BOUNCER_KEY_PATH must be set together.
+# CROWDSEC_LAPI_BOUNCER_CERT_PATH=/certs/blocklist-import-bouncer.pem
+# CROWDSEC_LAPI_BOUNCER_KEY_PATH=/certs/blocklist-import-bouncer-key.pem
 
 # =============================================================================
 # Decision Settings

--- a/README.md
+++ b/README.md
@@ -192,6 +192,53 @@ DECISION_DURATION=24h
 
 All credential variables support Docker Secrets via `_FILE` suffix (e.g., `CROWDSEC_LAPI_KEY_FILE=/run/secrets/lapi_key`).
 
+### LAPI HTTPS and Client Certificate Settings
+
+This importer is a client of CrowdSec LAPI. It has two independent TLS settings:
+
+- `CROWDSEC_LAPI_CA_CERT_PATH` verifies the HTTPS certificate served by LAPI. Use it when connecting to `https://...` and the LAPI server certificate is not trusted by the container's default CA store. This does not authenticate the importer to LAPI.
+- `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` present a client certificate to LAPI for mTLS/client-certificate authentication. These two variables are optional, but if one is set the other must also be set.
+
+For normal HTTPS plus machine credentials/API key:
+
+```bash
+CROWDSEC_LAPI_URL=https://crowdsec:8080
+CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
+CROWDSEC_LAPI_KEY=your_bouncer_key
+CROWDSEC_MACHINE_ID=blocklist-import
+CROWDSEC_MACHINE_PASSWORD=your_password
+```
+
+For LAPI client certificate authentication:
+
+```bash
+CROWDSEC_LAPI_URL=https://crowdsec:8080
+CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
+CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+# Optional and unrelated to the client cert/key:
+CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
+```
+
+When `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` are set, the importer presents that client certificate to LAPI and does not send the `X-Api-Key` header. Existing API key and machine JWT authentication continue to work when the client certificate/key are not configured.
+
+CrowdSec has two different CA settings that are easy to mix up:
+
+- `CROWDSEC_LAPI_CA_CERT_PATH` is client-side. It tells this importer which CA to trust for the LAPI HTTPS server certificate.
+- `api.server.tls.ca_cert_path` is server-side in CrowdSec. It tells LAPI which CA signed client certificates, so LAPI can verify `CROWDSEC_LAPI_CERT_PATH`.
+
+A CrowdSec config with only `cert_file` and `key_file` enables HTTPS for LAPI. It does not require, or enable, client certificate authentication by itself. To use client certificates as authentication, LAPI also needs a client-cert CA and allowed OU, for example:
+
+```yaml
+api:
+  server:
+    tls:
+      cert_file: /usr/local/etc/crowdsec/ssl/crowdsec_lapi.pem
+      key_file: /usr/local/etc/crowdsec/ssl/crowdsec_lapi_key.pem
+      ca_cert_path: /usr/local/etc/crowdsec/ssl/client_ca.pem
+      agents_allowed_ou:
+        - agent-ou
+```
+
 ### Common Settings
 
 | Variable | Default | Purpose |
@@ -508,6 +555,14 @@ docker network inspect crowdsec
 ```bash
 # Test bouncer key
 curl -H "X-Api-Key: YOUR_KEY" http://crowdsec:8080/decisions
+
+# Test TLS client certificate auth
+curl --cacert /certs/ca.pem \
+  --cert /certs/blocklist-import.pem \
+  --key /certs/blocklist-import-key.pem \
+  https://crowdsec:8080/v1/watchers/login \
+  -H "Content-Type: application/json" \
+  -d '{"machine_id":"blocklist-import","password":"YourPassword","scenarios":["external/blocklist"]}'
 
 # Test machine login
 curl -X POST http://crowdsec:8080/watchers/login \

--- a/README.md
+++ b/README.md
@@ -194,10 +194,13 @@ All credential variables support Docker Secrets via `_FILE` suffix (e.g., `CROWD
 
 ### LAPI HTTPS and Client Certificate Settings
 
-This importer is a client of CrowdSec LAPI. It has two independent TLS settings:
+This importer is a client of CrowdSec LAPI. It has three independent TLS/auth settings:
 
 - `CROWDSEC_LAPI_CA_CERT_PATH` verifies the HTTPS certificate served by LAPI. Use it when connecting to `https://...` and the LAPI server certificate is not trusted by the container's default CA store. This does not authenticate the importer to LAPI.
-- `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` present a client certificate to LAPI for mTLS/client-certificate authentication. These two variables are optional, but if one is set the other must also be set.
+- `CROWDSEC_LAPI_AGENT_CERT_PATH` and `CROWDSEC_LAPI_AGENT_KEY_PATH` present an agent client certificate to LAPI. CrowdSec uses this for watcher login/JWT auth, which is needed for writing alerts and decisions.
+- `CROWDSEC_LAPI_BOUNCER_CERT_PATH` and `CROWDSEC_LAPI_BOUNCER_KEY_PATH` present a bouncer client certificate to LAPI. CrowdSec uses this for bouncer auth, which is needed for reading existing decisions from `/v1/decisions`.
+
+Agent and bouncer certificate pairs are optional, but each pair must be complete if used.
 
 For normal HTTPS plus machine credentials/API key:
 
@@ -213,18 +216,20 @@ For LAPI client certificate authentication:
 
 ```bash
 CROWDSEC_LAPI_URL=https://crowdsec:8080
-CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
-CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+CROWDSEC_LAPI_AGENT_CERT_PATH=/certs/blocklist-import-agent.pem
+CROWDSEC_LAPI_AGENT_KEY_PATH=/certs/blocklist-import-agent-key.pem
+CROWDSEC_LAPI_BOUNCER_CERT_PATH=/certs/blocklist-import-bouncer.pem
+CROWDSEC_LAPI_BOUNCER_KEY_PATH=/certs/blocklist-import-bouncer-key.pem
 # Optional and unrelated to the client cert/key:
 CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
 ```
 
-When `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` are set, the importer presents that client certificate to LAPI and does not send the `X-Api-Key` header. Existing API key and machine JWT authentication continue to work when the client certificate/key are not configured.
+When `CROWDSEC_LAPI_BOUNCER_CERT_PATH` and `CROWDSEC_LAPI_BOUNCER_KEY_PATH` are set, the importer presents that bouncer certificate for decision reads and does not send the `X-Api-Key` header on those requests. Existing API key and machine JWT authentication continue to work when client certificate/key pairs are not configured.
 
 CrowdSec has two different CA settings that are easy to mix up:
 
 - `CROWDSEC_LAPI_CA_CERT_PATH` is client-side. It tells this importer which CA to trust for the LAPI HTTPS server certificate.
-- `api.server.tls.ca_cert_path` is server-side in CrowdSec. It tells LAPI which CA signed client certificates, so LAPI can verify `CROWDSEC_LAPI_CERT_PATH`.
+- `api.server.tls.ca_cert_path` is server-side in CrowdSec. It tells LAPI which CA signed client certificates, so LAPI can verify the agent and bouncer client certificates.
 
 A CrowdSec config with only `cert_file` and `key_file` enables HTTPS for LAPI. It does not require, or enable, client certificate authentication by itself. To use client certificates as authentication, LAPI also needs a client-cert CA and allowed OU, for example:
 
@@ -237,6 +242,8 @@ api:
       ca_cert_path: /usr/local/etc/crowdsec/ssl/client_ca.pem
       agents_allowed_ou:
         - agent-ou
+      bouncers_allowed_ou:
+        - bouncer-ou
 ```
 
 ### Common Settings

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -462,6 +462,9 @@ class Config:
     lapi_url: str = "http://localhost:8080"
     lapi_key: str = ""  # Bouncer API key (for reading decisions)
     lapi_key_file: str = ""  # Bouncer API key file (for reading decisions)
+    lapi_ca_cert_path: str = ""  # CA certificate path for LAPI TLS verification
+    lapi_cert_path: str = ""  # Client certificate path for LAPI mTLS authentication
+    lapi_key_path: str = ""  # Client private key path for LAPI mTLS authentication
 
     # Machine credentials (for writing decisions via /alerts endpoint)
     # These are alternative to lapi_key for write operations
@@ -562,6 +565,9 @@ class Config:
             lapi_url=os.getenv("CROWDSEC_LAPI_URL", "http://localhost:8080").rstrip("/"),
             lapi_key=os.getenv("CROWDSEC_LAPI_KEY", ""),
             lapi_key_file=os.getenv("CROWDSEC_LAPI_KEY_FILE", ""),
+            lapi_ca_cert_path=os.getenv("CROWDSEC_LAPI_CA_CERT_PATH", ""),
+            lapi_cert_path=os.getenv("CROWDSEC_LAPI_CERT_PATH", ""),
+            lapi_key_path=os.getenv("CROWDSEC_LAPI_KEY_PATH", ""),
             machine_id=os.getenv("CROWDSEC_MACHINE_ID", ""),
             machine_password=os.getenv("CROWDSEC_MACHINE_PASSWORD", ""),
             machine_password_file=os.getenv("CROWDSEC_MACHINE_PASSWORD_FILE", ""),
@@ -1392,6 +1398,43 @@ def create_http_session(max_retries: int = 3) -> requests.Session:
     return session
 
 
+def validate_lapi_tls_paths(
+    ca_cert_path: str = "",
+    cert_path: str = "",
+    key_path: str = "",
+) -> list[str]:
+    """Validate LAPI TLS certificate paths before handing them to requests."""
+    errors: list[str] = []
+    tls_values = {
+        "CROWDSEC_LAPI_CA_CERT_PATH": ca_cert_path,
+        "CROWDSEC_LAPI_CERT_PATH": cert_path,
+        "CROWDSEC_LAPI_KEY_PATH": key_path,
+    }
+
+    if not any(tls_values.values()):
+        return errors
+
+    if bool(cert_path) != bool(key_path):
+        errors.append(
+            "CROWDSEC_LAPI_CERT_PATH and CROWDSEC_LAPI_KEY_PATH must both "
+            "be set for LAPI TLS authentication"
+        )
+
+    for env_name, path in tls_values.items():
+        if not path:
+            continue
+        if not os.path.exists(path):
+            errors.append(f"{env_name} does not exist: {path}")
+            continue
+        if os.path.isdir(path):
+            errors.append(f"{env_name} must be a file, not a directory: {path}")
+            continue
+        if not os.access(path, os.R_OK):
+            errors.append(f"{env_name} is not readable: {path}")
+
+    return errors
+
+
 # =============================================================================
 # Blocklist Fetcher
 # =============================================================================
@@ -1572,8 +1615,9 @@ class CrowdSecLAPI:
     Supports two authentication modes:
     1. Bouncer API key (X-Api-Key header) - read-only access to decisions
     2. Machine credentials (JWT token) - full access including writing alerts/decisions
+    3. TLS client certificate authentication - LAPI authenticates the cert CN/OU
 
-    For writing decisions, machine credentials are required.
+    For writing decisions, machine credentials or TLS client certificate auth are required.
     """
 
     def __init__(
@@ -1583,22 +1627,37 @@ class CrowdSecLAPI:
         machine_id: str,
         machine_password: str,
         logger: logging.Logger,
+        ca_cert_path: str = "",
+        cert_path: str = "",
+        key_path: str = "",
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.machine_id = machine_id
         self.machine_password = machine_password
+        self.ca_cert_path = ca_cert_path
+        self.cert_path = cert_path
+        self.key_path = key_path
+        self.tls_enabled = bool(cert_path and key_path)
         self.session = create_http_session(10)
         self.logger = logger
         self.jwt_token: Optional[str] = None
         self.jwt_expires: Optional[float] = None
 
-        # Headers for bouncer API (read operations)
+        if ca_cert_path:
+            self.session.verify = ca_cert_path
+        if self.tls_enabled:
+            self.session.cert = (cert_path, key_path)
+            self.logger.debug("Configured LAPI client certificate authentication")
+
+        # Headers for bouncer API (read operations). TLS auth intentionally omits
+        # X-Api-Key so CrowdSec can authenticate the client certificate.
         self.bouncer_headers = {
-            "X-Api-Key": api_key,
             "Content-Type": "application/json",
             "User-Agent": f"crowdsec-blocklist-import/{__version__}",
         }
+        if not self.tls_enabled:
+            self.bouncer_headers["X-Api-Key"] = api_key
 
     def _get_machine_token(self) -> Optional[str]:
         """Get JWT token for machine authentication."""
@@ -1606,17 +1665,21 @@ class CrowdSecLAPI:
         if self.jwt_token and self.jwt_expires and time.time() < self.jwt_expires - 60:
             return self.jwt_token
 
-        if not self.machine_id or not self.machine_password:
+        if not self.tls_enabled and (not self.machine_id or not self.machine_password):
             return None
 
         try:
+            auth_payload: dict[str, object] = {
+                "scenarios": ["external/blocklist"],
+            }
+            if self.machine_id:
+                auth_payload["machine_id"] = self.machine_id
+            if self.machine_password:
+                auth_payload["password"] = self.machine_password
+
             response = self.session.post(
                 f"{self.base_url}/v1/watchers/login",
-                json={
-                    "machine_id": self.machine_id,
-                    "password": self.machine_password,
-                    "scenarios": ["external/blocklist"],
-                },
+                json=auth_payload,
                 headers={
                     "Content-Type": "application/json",
                     "User-Agent": f"crowdsec-blocklist-import/{__version__}",
@@ -1677,7 +1740,7 @@ class CrowdSecLAPI:
 
     def can_write(self) -> bool:
         """Check if we have credentials for write operations."""
-        return bool(self.machine_id and self.machine_password)
+        return self.tls_enabled or bool(self.machine_id and self.machine_password)
 
     def get_existing_ips(self) -> list[tuple[str, timedelta]]:
         """
@@ -1929,6 +1992,16 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
         machine_password = read_secret_file(config.machine_password_file)
         logger.debug(f"Read machine password from {config.machine_password_file}")
 
+    tls_errors = validate_lapi_tls_paths(
+        config.lapi_ca_cert_path,
+        config.lapi_cert_path,
+        config.lapi_key_path,
+    )
+    if tls_errors:
+        for error in tls_errors:
+            logger.error(error)
+        return stats
+
     # Initialize LAPI client
     lapi = CrowdSecLAPI(
         base_url=config.lapi_url,
@@ -1936,6 +2009,9 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
         machine_id=config.machine_id,
         machine_password=machine_password,
         logger=logger,
+        ca_cert_path=config.lapi_ca_cert_path,
+        cert_path=config.lapi_cert_path,
+        key_path=config.lapi_key_path,
     )
 
     if config.abuseipdb_api_key_file:
@@ -1944,12 +2020,14 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
 
     # Check LAPI connectivity (unless dry run)
     if not config.dry_run:
-        # Need either bouncer key (for reading) or machine creds (for writing)
-        if not lapi_key and not (config.machine_id and machine_password):
+        # Need bouncer key, machine creds, or client certificate auth.
+        if not lapi.tls_enabled and not lapi_key and not (config.machine_id and machine_password):
             logger.error(
                 "Authentication required. Set either:\n"
                 "  - CROWDSEC_LAPI_KEY or CROWDSEC_LAPI_KEY_FILE (bouncer key for read-only)\n"
-                "  - CROWDSEC_MACHINE_ID + CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE (for full access)"
+                "  - CROWDSEC_MACHINE_ID + CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE (for full access)\n"
+                "  - CROWDSEC_LAPI_CERT_PATH + CROWDSEC_LAPI_KEY_PATH "
+                "(client certificate auth)"
             )
             return stats
 
@@ -1957,7 +2035,9 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
         if not lapi.can_write():
             logger.error(
                 "Machine credentials required for writing decisions.\n"
-                "Set CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE.\n"
+                "Set CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE,\n"
+                "or set CROWDSEC_LAPI_CERT_PATH and CROWDSEC_LAPI_KEY_PATH "
+                "for client certificate auth.\n"
                 "Get these from: cscli machines list (or register a new machine)"
             )
             return stats
@@ -2394,6 +2474,9 @@ def parse_args() -> argparse.Namespace:
 Environment Variables:
   CROWDSEC_LAPI_URL        CrowdSec LAPI URL (default: http://localhost:8080)
   CROWDSEC_LAPI_KEY[_FILE] CrowdSec LAPI key / key file (required)
+  CROWDSEC_LAPI_CA_CERT_PATH  Optional trust bundle for LAPI HTTPS verification
+  CROWDSEC_LAPI_CERT_PATH     Optional client certificate for LAPI mTLS auth
+  CROWDSEC_LAPI_KEY_PATH      Optional client private key for LAPI mTLS auth
   DECISION_DURATION        How long decisions last (default: 24h)
   BATCH_SIZE               IPs per batch (default: 1000)
   LOG_LEVEL                DEBUG, INFO, WARN, ERROR (default: INFO)

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -1678,6 +1678,8 @@ class CrowdSecLAPI:
         if self.agent_tls_enabled:
             self.session.cert = (agent_cert_path, agent_key_path)
             self.logger.debug("Configured LAPI agent certificate authentication")
+
+        if self.agent_tls_enabled or self.bouncer_tls_enabled:
             if not self.base_url.startswith("https://"):
                 self.logger.warning(
                     "LAPI URL does not use HTTPS; client certificates are only "
@@ -1685,7 +1687,6 @@ class CrowdSecLAPI:
                     "for mTLS authentication."
                 )
 
-        if self.agent_tls_enabled or self.bouncer_tls_enabled:
             self.bouncer_session = create_http_session(10)
             if ca_cert_path:
                 self.bouncer_session.verify = ca_cert_path

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -463,8 +463,10 @@ class Config:
     lapi_key: str = ""  # Bouncer API key (for reading decisions)
     lapi_key_file: str = ""  # Bouncer API key file (for reading decisions)
     lapi_ca_cert_path: str = ""  # CA certificate path for LAPI TLS verification
-    lapi_cert_path: str = ""  # Client certificate path for LAPI mTLS authentication
-    lapi_key_path: str = ""  # Client private key path for LAPI mTLS authentication
+    lapi_agent_cert_path: str = ""  # Agent client cert for JWT/write auth
+    lapi_agent_key_path: str = ""  # Agent client key for JWT/write auth
+    lapi_bouncer_cert_path: str = ""  # Bouncer client cert for decision reads
+    lapi_bouncer_key_path: str = ""  # Bouncer client key for decision reads
 
     # Machine credentials (for writing decisions via /alerts endpoint)
     # These are alternative to lapi_key for write operations
@@ -566,8 +568,10 @@ class Config:
             lapi_key=os.getenv("CROWDSEC_LAPI_KEY", ""),
             lapi_key_file=os.getenv("CROWDSEC_LAPI_KEY_FILE", ""),
             lapi_ca_cert_path=os.getenv("CROWDSEC_LAPI_CA_CERT_PATH", ""),
-            lapi_cert_path=os.getenv("CROWDSEC_LAPI_CERT_PATH", ""),
-            lapi_key_path=os.getenv("CROWDSEC_LAPI_KEY_PATH", ""),
+            lapi_agent_cert_path=os.getenv("CROWDSEC_LAPI_AGENT_CERT_PATH", ""),
+            lapi_agent_key_path=os.getenv("CROWDSEC_LAPI_AGENT_KEY_PATH", ""),
+            lapi_bouncer_cert_path=os.getenv("CROWDSEC_LAPI_BOUNCER_CERT_PATH", ""),
+            lapi_bouncer_key_path=os.getenv("CROWDSEC_LAPI_BOUNCER_KEY_PATH", ""),
             machine_id=os.getenv("CROWDSEC_MACHINE_ID", ""),
             machine_password=os.getenv("CROWDSEC_MACHINE_PASSWORD", ""),
             machine_password_file=os.getenv("CROWDSEC_MACHINE_PASSWORD_FILE", ""),
@@ -1402,13 +1406,15 @@ def validate_lapi_tls_paths(
     ca_cert_path: str = "",
     cert_path: str = "",
     key_path: str = "",
+    cert_env_name: str = "CROWDSEC_LAPI_AGENT_CERT_PATH",
+    key_env_name: str = "CROWDSEC_LAPI_AGENT_KEY_PATH",
 ) -> list[str]:
     """Validate LAPI TLS certificate paths before handing them to requests."""
     errors: list[str] = []
     tls_values = {
         "CROWDSEC_LAPI_CA_CERT_PATH": ca_cert_path,
-        "CROWDSEC_LAPI_CERT_PATH": cert_path,
-        "CROWDSEC_LAPI_KEY_PATH": key_path,
+        cert_env_name: cert_path,
+        key_env_name: key_path,
     }
 
     if not any(tls_values.values()):
@@ -1416,7 +1422,7 @@ def validate_lapi_tls_paths(
 
     if bool(cert_path) != bool(key_path):
         errors.append(
-            "CROWDSEC_LAPI_CERT_PATH and CROWDSEC_LAPI_KEY_PATH must both "
+            f"{cert_env_name} and {key_env_name} must both "
             "be set for LAPI TLS authentication"
         )
 
@@ -1433,6 +1439,22 @@ def validate_lapi_tls_paths(
             errors.append(f"{env_name} is not readable: {path}")
 
     return errors
+
+
+def warn_lapi_private_key_permissions(
+    logger: logging.Logger,
+    key_paths: dict[str, str],
+) -> None:
+    """Warn when private key files are readable by group or other users."""
+    for env_name, key_path in key_paths.items():
+        if not key_path or not os.path.exists(key_path):
+            continue
+        mode = os.stat(key_path).st_mode & 0o777
+        if mode & 0o077:
+            logger.warning(
+                f"{env_name} permissions are {oct(mode)[2:]}; "
+                "private key files should usually be 600 or 400"
+            )
 
 
 # =============================================================================
@@ -1615,9 +1637,10 @@ class CrowdSecLAPI:
     Supports two authentication modes:
     1. Bouncer API key (X-Api-Key header) - read-only access to decisions
     2. Machine credentials (JWT token) - full access including writing alerts/decisions
-    3. TLS client certificate authentication - LAPI authenticates the cert CN/OU
+    3. TLS client certificate authentication - separate agent and bouncer cert roles
 
-    For writing decisions, machine credentials or TLS client certificate auth are required.
+    For writing decisions, machine credentials or an agent TLS cert are required.
+    For reading decisions, a bouncer API key or bouncer TLS cert is preferred.
     """
 
     def __init__(
@@ -1628,17 +1651,23 @@ class CrowdSecLAPI:
         machine_password: str,
         logger: logging.Logger,
         ca_cert_path: str = "",
-        cert_path: str = "",
-        key_path: str = "",
+        agent_cert_path: str = "",
+        agent_key_path: str = "",
+        bouncer_cert_path: str = "",
+        bouncer_key_path: str = "",
     ):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.machine_id = machine_id
         self.machine_password = machine_password
         self.ca_cert_path = ca_cert_path
-        self.cert_path = cert_path
-        self.key_path = key_path
-        self.tls_enabled = bool(cert_path and key_path)
+        self.agent_cert_path = agent_cert_path
+        self.agent_key_path = agent_key_path
+        self.bouncer_cert_path = bouncer_cert_path
+        self.bouncer_key_path = bouncer_key_path
+        self.agent_tls_enabled = bool(agent_cert_path and agent_key_path)
+        self.bouncer_tls_enabled = bool(bouncer_cert_path and bouncer_key_path)
+        self.tls_enabled = self.agent_tls_enabled or self.bouncer_tls_enabled
         self.session = create_http_session(10)
         self.logger = logger
         self.jwt_token: Optional[str] = None
@@ -1646,17 +1675,34 @@ class CrowdSecLAPI:
 
         if ca_cert_path:
             self.session.verify = ca_cert_path
-        if self.tls_enabled:
-            self.session.cert = (cert_path, key_path)
-            self.logger.debug("Configured LAPI client certificate authentication")
+        if self.agent_tls_enabled:
+            self.session.cert = (agent_cert_path, agent_key_path)
+            self.logger.debug("Configured LAPI agent certificate authentication")
+            if not self.base_url.startswith("https://"):
+                self.logger.warning(
+                    "LAPI URL does not use HTTPS; client certificates are only "
+                    "sent over TLS. Set CROWDSEC_LAPI_URL to an https:// URL "
+                    "for mTLS authentication."
+                )
 
-        # Headers for bouncer API (read operations). TLS auth intentionally omits
-        # X-Api-Key so CrowdSec can authenticate the client certificate.
+        if self.agent_tls_enabled or self.bouncer_tls_enabled:
+            self.bouncer_session = create_http_session(10)
+            if ca_cert_path:
+                self.bouncer_session.verify = ca_cert_path
+        else:
+            self.bouncer_session = self.session
+
+        if self.bouncer_tls_enabled:
+            self.bouncer_session.cert = (bouncer_cert_path, bouncer_key_path)
+            self.logger.debug("Configured LAPI bouncer certificate authentication")
+
+        # Headers for bouncer API (read operations). Bouncer TLS auth omits
+        # X-Api-Key so CrowdSec can authenticate the bouncer certificate.
         self.bouncer_headers = {
             "Content-Type": "application/json",
             "User-Agent": f"crowdsec-blocklist-import/{__version__}",
         }
-        if not self.tls_enabled:
+        if not self.bouncer_tls_enabled and api_key:
             self.bouncer_headers["X-Api-Key"] = api_key
 
     def _get_machine_token(self) -> Optional[str]:
@@ -1665,7 +1711,10 @@ class CrowdSecLAPI:
         if self.jwt_token and self.jwt_expires and time.time() < self.jwt_expires - 60:
             return self.jwt_token
 
-        if not self.tls_enabled and (not self.machine_id or not self.machine_password):
+        if (
+            not self.agent_tls_enabled
+            and (not self.machine_id or not self.machine_password)
+        ):
             return None
 
         try:
@@ -1726,7 +1775,7 @@ class CrowdSecLAPI:
     def health_check(self) -> bool:
         """Check if LAPI is accessible."""
         try:
-            response = self.session.get(
+            response = self.bouncer_session.get(
                 f"{self.base_url}/v1/decisions",
                 headers=self.bouncer_headers,
                 timeout=10,
@@ -1740,7 +1789,7 @@ class CrowdSecLAPI:
 
     def can_write(self) -> bool:
         """Check if we have credentials for write operations."""
-        return self.tls_enabled or bool(self.machine_id and self.machine_password)
+        return self.agent_tls_enabled or bool(self.machine_id and self.machine_password)
 
     def get_existing_ips(self) -> list[tuple[str, timedelta]]:
         """
@@ -1753,12 +1802,19 @@ class CrowdSecLAPI:
         existing: list[tuple[str, timedelta]] = []
 
         try:
-            # Prefer machine JWT auth — returns the full decision set
-            # (bouncer API returns a stream delta after the first pull,
-            #  causing subsequent runs to see 0 decisions and reimport everything)
-            headers = self._get_machine_headers() or self.bouncer_headers
+            if self.bouncer_tls_enabled or self.api_key:
+                headers = self.bouncer_headers
+                session = self.bouncer_session
+            else:
+                # This usually returns 403 because /v1/decisions is a bouncer
+                # endpoint, but keep the attempt for compatibility with older
+                # CrowdSec deployments.
+                headers = self._get_machine_headers()
+                session = self.session
+                if not headers:
+                    return existing
 
-            response = self.session.get(
+            response = session.get(
                 f"{self.base_url}/v1/decisions",
                 headers=headers,
                 timeout=120,
@@ -1775,7 +1831,10 @@ class CrowdSecLAPI:
                         if value:
                             existing.append((value, expiration))
             elif response.status_code == 403 and headers is self.bouncer_headers:
-                self.logger.error("Forbidden: check your LAPI_API_KEY")
+                self.logger.error(
+                    "Forbidden: check your LAPI bouncer API key or "
+                    "bouncer client certificate"
+                )
                 self.logger.error(f"Response: {response}")
             elif response.status_code == 403:
                 # Machine JWT failed — fall back to bouncer auth
@@ -1799,7 +1858,7 @@ class CrowdSecLAPI:
         """Fallback: fetch decisions using bouncer API key (stream mode — may be incomplete)."""
         existing: list[tuple[str, timedelta]] = []
         try:
-            response = self.session.get(
+            response = self.bouncer_session.get(
                 f"{self.base_url}/v1/decisions",
                 headers=self.bouncer_headers,
                 timeout=60,
@@ -1884,8 +1943,9 @@ class CrowdSecLAPI:
         headers = self._get_machine_headers()
         if not headers:
             self.logger.error(
-                "Machine credentials required for writing decisions. "
-                "Set CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE"
+                "Cannot write decisions: no machine JWT token available. "
+                "Set CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD or "
+                "CROWDSEC_LAPI_AGENT_CERT_PATH and CROWDSEC_LAPI_AGENT_KEY_PATH"
             )
             return 0, len(ips)
 
@@ -1994,8 +2054,26 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
 
     tls_errors = validate_lapi_tls_paths(
         config.lapi_ca_cert_path,
-        config.lapi_cert_path,
-        config.lapi_key_path,
+        config.lapi_agent_cert_path,
+        config.lapi_agent_key_path,
+        cert_env_name="CROWDSEC_LAPI_AGENT_CERT_PATH",
+        key_env_name="CROWDSEC_LAPI_AGENT_KEY_PATH",
+    )
+    tls_errors.extend(
+        validate_lapi_tls_paths(
+            "",
+            config.lapi_bouncer_cert_path,
+            config.lapi_bouncer_key_path,
+            cert_env_name="CROWDSEC_LAPI_BOUNCER_CERT_PATH",
+            key_env_name="CROWDSEC_LAPI_BOUNCER_KEY_PATH",
+        )
+    )
+    warn_lapi_private_key_permissions(
+        logger,
+        {
+            "CROWDSEC_LAPI_AGENT_KEY_PATH": config.lapi_agent_key_path,
+            "CROWDSEC_LAPI_BOUNCER_KEY_PATH": config.lapi_bouncer_key_path,
+        },
     )
     if tls_errors:
         for error in tls_errors:
@@ -2010,8 +2088,10 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
         machine_password=machine_password,
         logger=logger,
         ca_cert_path=config.lapi_ca_cert_path,
-        cert_path=config.lapi_cert_path,
-        key_path=config.lapi_key_path,
+        agent_cert_path=config.lapi_agent_cert_path,
+        agent_key_path=config.lapi_agent_key_path,
+        bouncer_cert_path=config.lapi_bouncer_cert_path,
+        bouncer_key_path=config.lapi_bouncer_key_path,
     )
 
     if config.abuseipdb_api_key_file:
@@ -2026,8 +2106,10 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
                 "Authentication required. Set either:\n"
                 "  - CROWDSEC_LAPI_KEY or CROWDSEC_LAPI_KEY_FILE (bouncer key for read-only)\n"
                 "  - CROWDSEC_MACHINE_ID + CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE (for full access)\n"
-                "  - CROWDSEC_LAPI_CERT_PATH + CROWDSEC_LAPI_KEY_PATH "
-                "(client certificate auth)"
+                "  - CROWDSEC_LAPI_AGENT_CERT_PATH + CROWDSEC_LAPI_AGENT_KEY_PATH "
+                "(agent client certificate auth)\n"
+                "  - CROWDSEC_LAPI_BOUNCER_CERT_PATH + CROWDSEC_LAPI_BOUNCER_KEY_PATH "
+                "(bouncer client certificate auth)"
             )
             return stats
 
@@ -2036,8 +2118,8 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
             logger.error(
                 "Machine credentials required for writing decisions.\n"
                 "Set CROWDSEC_MACHINE_ID and CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE,\n"
-                "or set CROWDSEC_LAPI_CERT_PATH and CROWDSEC_LAPI_KEY_PATH "
-                "for client certificate auth.\n"
+                "or set CROWDSEC_LAPI_AGENT_CERT_PATH and CROWDSEC_LAPI_AGENT_KEY_PATH "
+                "for agent client certificate auth.\n"
                 "Get these from: cscli machines list (or register a new machine)"
             )
             return stats
@@ -2475,8 +2557,10 @@ Environment Variables:
   CROWDSEC_LAPI_URL        CrowdSec LAPI URL (default: http://localhost:8080)
   CROWDSEC_LAPI_KEY[_FILE] CrowdSec LAPI key / key file (required)
   CROWDSEC_LAPI_CA_CERT_PATH  Optional trust bundle for LAPI HTTPS verification
-  CROWDSEC_LAPI_CERT_PATH     Optional client certificate for LAPI mTLS auth
-  CROWDSEC_LAPI_KEY_PATH      Optional client private key for LAPI mTLS auth
+  CROWDSEC_LAPI_AGENT_CERT_PATH   Agent client cert for JWT/write auth
+  CROWDSEC_LAPI_AGENT_KEY_PATH    Agent client key for JWT/write auth
+  CROWDSEC_LAPI_BOUNCER_CERT_PATH Bouncer client cert for decision reads
+  CROWDSEC_LAPI_BOUNCER_KEY_PATH  Bouncer client key for decision reads
   DECISION_DURATION        How long decisions last (default: 24h)
   BATCH_SIZE               IPs per batch (default: 1000)
   LOG_LEVEL                DEBUG, INFO, WARN, ERROR (default: INFO)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -23,12 +23,41 @@ These variables must be set before the application can run. The application will
 | CROWDSEC_MACHINE_ID | Machine identifier for authentication | `blocklist-import` |
 | CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE | Machine password or path to Docker secret file | `mypassword` or `/run/secrets/machine_password` |
 
+For HTTPS LAPI deployments, `CROWDSEC_LAPI_CA_CERT_PATH` can be used to verify the HTTPS certificate served by LAPI. For LAPI client certificate authentication, `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` can be used instead of the bouncer key and machine credentials. These settings are independent.
+
 ### Notes on Required Variables
 
 - **Docker Secrets:** Use the `_FILE` suffix to reference mounted secret files instead of passing credentials directly
 - **LAPI_URL:** Must include protocol (http/https) and port. Default is `http://localhost:8080`
 - **Key vs Key_FILE:** Provide either `CROWDSEC_LAPI_KEY` OR `CROWDSEC_LAPI_KEY_FILE`, not both
 - **Password vs Password_FILE:** Provide either `CROWDSEC_MACHINE_PASSWORD` OR `CROWDSEC_MACHINE_PASSWORD_FILE`, not both
+
+---
+
+## LAPI HTTPS and Client Certificate Settings
+
+Use these variables for HTTPS server verification and optional client certificate authentication.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| CROWDSEC_LAPI_CA_CERT_PATH | CA/trust bundle used by this importer to verify the HTTPS certificate served by LAPI | `/certs/crowdsec_lapi.pem` |
+| CROWDSEC_LAPI_CERT_PATH | Client certificate presented to LAPI | `/certs/blocklist-import.pem` |
+| CROWDSEC_LAPI_KEY_PATH | Client private key for the certificate | `/certs/blocklist-import-key.pem` |
+
+`CROWDSEC_LAPI_CA_CERT_PATH` is optional and unrelated to client certificate authentication. It only controls how the importer verifies the LAPI HTTPS server certificate.
+
+`CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` are also optional, but they must be set together. When both are set, requests to LAPI use mTLS/client-certificate authentication and the importer does not send the `X-Api-Key` header. If the client certificate/key variables are not set, the existing bouncer API key and machine JWT behavior is unchanged.
+
+```bash
+CROWDSEC_LAPI_URL=https://crowdsec:8080
+CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
+```
+
+```bash
+CROWDSEC_LAPI_URL=https://crowdsec:8080
+CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
+CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+```
 
 ---
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -23,7 +23,7 @@ These variables must be set before the application can run. The application will
 | CROWDSEC_MACHINE_ID | Machine identifier for authentication | `blocklist-import` |
 | CROWDSEC_MACHINE_PASSWORD or CROWDSEC_MACHINE_PASSWORD_FILE | Machine password or path to Docker secret file | `mypassword` or `/run/secrets/machine_password` |
 
-For HTTPS LAPI deployments, `CROWDSEC_LAPI_CA_CERT_PATH` can be used to verify the HTTPS certificate served by LAPI. For LAPI client certificate authentication, `CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` can be used instead of the bouncer key and machine credentials. These settings are independent.
+For HTTPS LAPI deployments, `CROWDSEC_LAPI_CA_CERT_PATH` can be used to verify the HTTPS certificate served by LAPI. For LAPI client certificate authentication, agent and bouncer certificate pairs can be used for their respective CrowdSec auth middlewares. These settings are independent.
 
 ### Notes on Required Variables
 
@@ -41,12 +41,14 @@ Use these variables for HTTPS server verification and optional client certificat
 | Variable | Description | Example |
 |----------|-------------|---------|
 | CROWDSEC_LAPI_CA_CERT_PATH | CA/trust bundle used by this importer to verify the HTTPS certificate served by LAPI | `/certs/crowdsec_lapi.pem` |
-| CROWDSEC_LAPI_CERT_PATH | Client certificate presented to LAPI | `/certs/blocklist-import.pem` |
-| CROWDSEC_LAPI_KEY_PATH | Client private key for the certificate | `/certs/blocklist-import-key.pem` |
+| CROWDSEC_LAPI_AGENT_CERT_PATH | Agent client certificate used for watcher login/JWT write auth | `/certs/blocklist-import-agent.pem` |
+| CROWDSEC_LAPI_AGENT_KEY_PATH | Agent client private key | `/certs/blocklist-import-agent-key.pem` |
+| CROWDSEC_LAPI_BOUNCER_CERT_PATH | Bouncer client certificate used for decision reads | `/certs/blocklist-import-bouncer.pem` |
+| CROWDSEC_LAPI_BOUNCER_KEY_PATH | Bouncer client private key | `/certs/blocklist-import-bouncer-key.pem` |
 
 `CROWDSEC_LAPI_CA_CERT_PATH` is optional and unrelated to client certificate authentication. It only controls how the importer verifies the LAPI HTTPS server certificate.
 
-`CROWDSEC_LAPI_CERT_PATH` and `CROWDSEC_LAPI_KEY_PATH` are also optional, but they must be set together. When both are set, requests to LAPI use mTLS/client-certificate authentication and the importer does not send the `X-Api-Key` header. If the client certificate/key variables are not set, the existing bouncer API key and machine JWT behavior is unchanged.
+The agent and bouncer client certificate/key pairs are optional, but each pair must be set together if used. CrowdSec uses agent certificates for watcher login/JWT endpoints such as `/v1/alerts`, while bouncer certificates are used for bouncer endpoints such as `/v1/decisions`. If client certificate/key variables are not set, the existing bouncer API key and machine JWT behavior is unchanged.
 
 ```bash
 CROWDSEC_LAPI_URL=https://crowdsec:8080
@@ -55,8 +57,10 @@ CROWDSEC_LAPI_CA_CERT_PATH=/certs/crowdsec_lapi.pem
 
 ```bash
 CROWDSEC_LAPI_URL=https://crowdsec:8080
-CROWDSEC_LAPI_CERT_PATH=/certs/blocklist-import.pem
-CROWDSEC_LAPI_KEY_PATH=/certs/blocklist-import-key.pem
+CROWDSEC_LAPI_AGENT_CERT_PATH=/certs/blocklist-import-agent.pem
+CROWDSEC_LAPI_AGENT_KEY_PATH=/certs/blocklist-import-agent-key.pem
+CROWDSEC_LAPI_BOUNCER_CERT_PATH=/certs/blocklist-import-bouncer.pem
+CROWDSEC_LAPI_BOUNCER_KEY_PATH=/certs/blocklist-import-bouncer-key.pem
 ```
 
 ---

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -200,11 +200,34 @@ def menu_crowdsec_connection(state):
     )
 
     print()
+    print("  Optional TLS client certificate auth — leave blank unless LAPI requires mTLS.")
+    state["CROWDSEC_LAPI_CA_CERT_PATH"] = prompt_input(
+        "  CROWDSEC_LAPI_CA_CERT_PATH",
+        default=state.get("CROWDSEC_LAPI_CA_CERT_PATH", ""),
+    )
+    state["CROWDSEC_LAPI_CERT_PATH"] = prompt_input(
+        "  CROWDSEC_LAPI_CERT_PATH",
+        default=state.get("CROWDSEC_LAPI_CERT_PATH", ""),
+    )
+    state["CROWDSEC_LAPI_KEY_PATH"] = prompt_input(
+        "  CROWDSEC_LAPI_KEY_PATH",
+        default=state.get("CROWDSEC_LAPI_KEY_PATH", ""),
+    )
+
+    print()
     if state.get("CROWDSEC_LAPI_URL") and prompt_yn("  Test connection now?", default=False):
         url = state["CROWDSEC_LAPI_URL"].rstrip("/")
         try:
             import requests
-            resp = requests.get(f"{url}/health", timeout=5)
+            request_kwargs = {"timeout": 5}
+            if state.get("CROWDSEC_LAPI_CA_CERT_PATH"):
+                request_kwargs["verify"] = state["CROWDSEC_LAPI_CA_CERT_PATH"]
+            if state.get("CROWDSEC_LAPI_CERT_PATH") and state.get("CROWDSEC_LAPI_KEY_PATH"):
+                request_kwargs["cert"] = (
+                    state["CROWDSEC_LAPI_CERT_PATH"],
+                    state["CROWDSEC_LAPI_KEY_PATH"],
+                )
+            resp = requests.get(f"{url}/health", **request_kwargs)
             if resp.status_code == 200:
                 print_status("Health check", "OK (200)", good=True)
             else:
@@ -361,7 +384,8 @@ def _build_env_lines(state):
 
     for key in ("CROWDSEC_LAPI_URL", "CROWDSEC_LAPI_KEY", "CROWDSEC_LAPI_KEY_FILE",
                 "CROWDSEC_MACHINE_ID", "CROWDSEC_MACHINE_PASSWORD",
-                "CROWDSEC_MACHINE_PASSWORD_FILE"):
+                "CROWDSEC_MACHINE_PASSWORD_FILE", "CROWDSEC_LAPI_CA_CERT_PATH",
+                "CROWDSEC_LAPI_CERT_PATH", "CROWDSEC_LAPI_KEY_PATH"):
         if state.get(key):
             lines.append(f"{key}={state[key]}")
 
@@ -531,7 +555,8 @@ def menu_view_config(state):
     sections = {
         "CrowdSec Connection": [
             "CROWDSEC_LAPI_URL", "CROWDSEC_LAPI_KEY", "CROWDSEC_MACHINE_ID",
-            "CROWDSEC_MACHINE_PASSWORD",
+            "CROWDSEC_MACHINE_PASSWORD", "CROWDSEC_LAPI_CA_CERT_PATH",
+            "CROWDSEC_LAPI_CERT_PATH", "CROWDSEC_LAPI_KEY_PATH",
         ],
         "Decision Settings": [
             "DECISION_DURATION", "DECISION_REASON", "DECISION_TYPE",

--- a/test_blocklist_import.py
+++ b/test_blocklist_import.py
@@ -124,6 +124,7 @@ def lapi(session_mock, logger):
         logger=logger,
     )
     obj.session = session_mock
+    obj.bouncer_session = session_mock
     return obj
 
 
@@ -179,12 +180,16 @@ class TestConfigFromEnv:
 
     def test_lapi_tls_paths_loaded(self, clean_env):
         clean_env.setenv("CROWDSEC_LAPI_CA_CERT_PATH", "/certs/ca.pem")
-        clean_env.setenv("CROWDSEC_LAPI_CERT_PATH", "/certs/client.pem")
-        clean_env.setenv("CROWDSEC_LAPI_KEY_PATH", "/certs/client-key.pem")
+        clean_env.setenv("CROWDSEC_LAPI_AGENT_CERT_PATH", "/certs/agent.pem")
+        clean_env.setenv("CROWDSEC_LAPI_AGENT_KEY_PATH", "/certs/agent-key.pem")
+        clean_env.setenv("CROWDSEC_LAPI_BOUNCER_CERT_PATH", "/certs/bouncer.pem")
+        clean_env.setenv("CROWDSEC_LAPI_BOUNCER_KEY_PATH", "/certs/bouncer-key.pem")
         cfg = Config.from_env()
         assert cfg.lapi_ca_cert_path == "/certs/ca.pem"
-        assert cfg.lapi_cert_path == "/certs/client.pem"
-        assert cfg.lapi_key_path == "/certs/client-key.pem"
+        assert cfg.lapi_agent_cert_path == "/certs/agent.pem"
+        assert cfg.lapi_agent_key_path == "/certs/agent-key.pem"
+        assert cfg.lapi_bouncer_cert_path == "/certs/bouncer.pem"
+        assert cfg.lapi_bouncer_key_path == "/certs/bouncer-key.pem"
 
     def test_machine_credentials(self, clean_env):
         clean_env.setenv("CROWDSEC_MACHINE_ID", "myid")
@@ -767,9 +772,29 @@ class TestCrowdSecLAPIHealthCheck:
         session_mock.get.side_effect = requests.RequestException("timeout")
         assert lapi.health_check() is False
 
+    def test_health_check_uses_bouncer_session_for_bouncer_tls(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
+            bouncer_cert_path="/certs/bouncer.pem",
+            bouncer_key_path="/certs/bouncer-key.pem",
+        )
+        lapi_tls.session = MagicMock()
+        lapi_tls.bouncer_session = MagicMock()
+        lapi_tls.bouncer_session.get.return_value = Mock(status_code=200)
+
+        assert lapi_tls.health_check() is True
+        lapi_tls.bouncer_session.get.assert_called_once()
+        lapi_tls.session.get.assert_not_called()
+
 
 class TestCrowdSecLAPITLS:
-    def test_tls_configures_session_cert_and_ca(self, logger):
+    def test_agent_tls_configures_write_session_cert_and_ca(self, logger):
         lapi_tls = CrowdSecLAPI(
             base_url="https://localhost:8080",
             api_key="ignored",
@@ -777,13 +802,52 @@ class TestCrowdSecLAPITLS:
             machine_password="",
             logger=logger,
             ca_cert_path="/certs/ca.pem",
-            cert_path="/certs/client.pem",
-            key_path="/certs/client-key.pem",
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
         )
         assert lapi_tls.tls_enabled is True
-        assert lapi_tls.session.cert == ("/certs/client.pem", "/certs/client-key.pem")
+        assert lapi_tls.agent_tls_enabled is True
+        assert lapi_tls.session.cert == ("/certs/agent.pem", "/certs/agent-key.pem")
         assert lapi_tls.session.verify == "/certs/ca.pem"
+
+    def test_bouncer_tls_configures_read_session_cert_and_ca(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="ignored",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            bouncer_cert_path="/certs/bouncer.pem",
+            bouncer_key_path="/certs/bouncer-key.pem",
+        )
+        assert lapi_tls.tls_enabled is True
+        assert lapi_tls.bouncer_tls_enabled is True
+        assert lapi_tls.bouncer_session.cert == (
+            "/certs/bouncer.pem",
+            "/certs/bouncer-key.pem",
+        )
+        assert lapi_tls.bouncer_session.verify == "/certs/ca.pem"
         assert "X-Api-Key" not in lapi_tls.bouncer_headers
+
+    def test_agent_and_bouncer_tls_use_separate_sessions(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="ignored",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
+            bouncer_cert_path="/certs/bouncer.pem",
+            bouncer_key_path="/certs/bouncer-key.pem",
+        )
+        assert lapi_tls.session.cert == ("/certs/agent.pem", "/certs/agent-key.pem")
+        assert lapi_tls.bouncer_session.cert == (
+            "/certs/bouncer.pem",
+            "/certs/bouncer-key.pem",
+        )
 
     def test_ca_path_only_verifies_server_without_mtls(self, logger):
         lapi_tls = CrowdSecLAPI(
@@ -796,9 +860,10 @@ class TestCrowdSecLAPITLS:
         )
         assert lapi_tls.tls_enabled is False
         assert lapi_tls.session.verify == "/certs/crowdsec_lapi.pem"
+        assert lapi_tls.bouncer_session.verify == "/certs/crowdsec_lapi.pem"
         assert lapi_tls.bouncer_headers["X-Api-Key"] == "key"
 
-    def test_tls_can_write_without_machine_credentials(self, logger):
+    def test_agent_tls_can_write_without_machine_credentials(self, logger):
         lapi_tls = CrowdSecLAPI(
             base_url="https://localhost:8080",
             api_key="",
@@ -806,12 +871,12 @@ class TestCrowdSecLAPITLS:
             machine_password="",
             logger=logger,
             ca_cert_path="/certs/ca.pem",
-            cert_path="/certs/client.pem",
-            key_path="/certs/client-key.pem",
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
         )
         assert lapi_tls.can_write() is True
 
-    def test_tls_machine_login_can_use_cert_only_payload(self, logger):
+    def test_bouncer_tls_cannot_write_without_machine_credentials(self, logger):
         lapi_tls = CrowdSecLAPI(
             base_url="https://localhost:8080",
             api_key="",
@@ -819,8 +884,21 @@ class TestCrowdSecLAPITLS:
             machine_password="",
             logger=logger,
             ca_cert_path="/certs/ca.pem",
-            cert_path="/certs/client.pem",
-            key_path="/certs/client-key.pem",
+            bouncer_cert_path="/certs/bouncer.pem",
+            bouncer_key_path="/certs/bouncer-key.pem",
+        )
+        assert lapi_tls.can_write() is False
+
+    def test_agent_tls_machine_login_can_use_cert_only_payload(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
         )
         lapi_tls.session = MagicMock()
         lapi_tls.session.post.return_value = Mock(
@@ -838,7 +916,7 @@ class TestCrowdSecLAPITLS:
         login_payload = lapi_tls.session.post.call_args.kwargs["json"]
         assert login_payload == {"scenarios": ["external/blocklist"]}
 
-    def test_tls_machine_login_includes_credentials_when_configured(self, logger):
+    def test_agent_tls_machine_login_includes_credentials_when_configured(self, logger):
         lapi_tls = CrowdSecLAPI(
             base_url="https://localhost:8080",
             api_key="",
@@ -846,8 +924,8 @@ class TestCrowdSecLAPITLS:
             machine_password="secret",
             logger=logger,
             ca_cert_path="/certs/ca.pem",
-            cert_path="/certs/client.pem",
-            key_path="/certs/client-key.pem",
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
         )
         lapi_tls.session = MagicMock()
         lapi_tls.session.post.return_value = Mock(
@@ -874,7 +952,11 @@ class TestCrowdSecLAPITLS:
         assert lapi.bouncer_headers["X-Api-Key"] == "testkey"
 
     def test_validate_lapi_tls_paths_requires_cert_key_pair(self):
-        errors = validate_lapi_tls_paths(cert_path="/certs/client.pem")
+        errors = validate_lapi_tls_paths(
+            cert_path="/certs/agent.pem",
+            cert_env_name="CROWDSEC_LAPI_AGENT_CERT_PATH",
+            key_env_name="CROWDSEC_LAPI_AGENT_KEY_PATH",
+        )
         assert any("must both be set" in error for error in errors)
 
     def test_validate_lapi_tls_paths_accepts_existing_files(self, tmp_path):
@@ -896,6 +978,17 @@ class TestCrowdSecLAPITLS:
         for path in (cert, key):
             path.write_text("test")
         assert validate_lapi_tls_paths(cert_path=str(cert), key_path=str(key)) == []
+
+    def test_warn_lapi_private_key_permissions_warns_for_loose_key(self, tmp_path, logger):
+        key = tmp_path / "client-key.pem"
+        key.write_text("test")
+        key.chmod(0o644)
+        with patch.object(logger, "warning") as warning:
+            bi.warn_lapi_private_key_permissions(
+                logger,
+                {"CROWDSEC_LAPI_AGENT_KEY_PATH": str(key)},
+            )
+        warning.assert_called_once()
 
 
 class TestCrowdSecLAPIGetExistingIPs:
@@ -939,6 +1032,59 @@ class TestCrowdSecLAPIGetExistingIPs:
         )
         existing = lapi.get_existing_ips()
         assert existing == []
+
+    def test_bouncer_tls_uses_bouncer_session_for_decision_reads(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
+            bouncer_cert_path="/certs/bouncer.pem",
+            bouncer_key_path="/certs/bouncer-key.pem",
+        )
+        lapi_tls.session = MagicMock()
+        lapi_tls.bouncer_session = MagicMock()
+        lapi_tls.bouncer_session.get.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=[{"value": "1.2.3.4"}]),
+        )
+
+        existing = lapi_tls.get_existing_ips()
+
+        assert existing == [("1.2.3.4", timedelta(seconds=0))]
+        lapi_tls.bouncer_session.get.assert_called_once()
+        lapi_tls.session.get.assert_not_called()
+        headers = lapi_tls.bouncer_session.get.call_args.kwargs["headers"]
+        assert "X-Api-Key" not in headers
+
+    def test_agent_tls_with_api_key_reads_without_agent_cert(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="key",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            agent_cert_path="/certs/agent.pem",
+            agent_key_path="/certs/agent-key.pem",
+        )
+        lapi_tls.session = MagicMock()
+        lapi_tls.bouncer_session = MagicMock()
+        lapi_tls.bouncer_session.cert = None
+        lapi_tls.bouncer_session.get.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value=[{"value": "5.6.7.8"}]),
+        )
+
+        existing = lapi_tls.get_existing_ips()
+
+        assert existing == [("5.6.7.8", timedelta(seconds=0))]
+        assert lapi_tls.bouncer_session.cert is None
+        assert lapi_tls.bouncer_headers["X-Api-Key"] == "key"
+        lapi_tls.bouncer_session.get.assert_called_once()
+        lapi_tls.session.get.assert_not_called()
 
 
 class TestCrowdSecLAPIAddDecisions:

--- a/test_blocklist_import.py
+++ b/test_blocklist_import.py
@@ -830,6 +830,20 @@ class TestCrowdSecLAPITLS:
         assert lapi_tls.bouncer_session.verify == "/certs/ca.pem"
         assert "X-Api-Key" not in lapi_tls.bouncer_headers
 
+    def test_bouncer_tls_warns_when_lapi_url_is_not_https(self, logger):
+        with patch.object(logger, "warning") as warning:
+            CrowdSecLAPI(
+                base_url="http://localhost:8080",
+                api_key="",
+                machine_id="",
+                machine_password="",
+                logger=logger,
+                bouncer_cert_path="/certs/bouncer.pem",
+                bouncer_key_path="/certs/bouncer-key.pem",
+            )
+
+        warning.assert_called_once()
+
     def test_agent_and_bouncer_tls_use_separate_sessions(self, logger):
         lapi_tls = CrowdSecLAPI(
             base_url="https://localhost:8080",

--- a/test_blocklist_import.py
+++ b/test_blocklist_import.py
@@ -60,6 +60,7 @@ from blocklist_import import (
     sanitize_error_message,
     validate_bool_value,
     validate_enable_env_vars,
+    validate_lapi_tls_paths,
     get_abuseipdb_api_headers,
     get_abuseipdb_api_params,
     get_abuseipdb_api_can_import,
@@ -175,6 +176,15 @@ class TestConfigFromEnv:
         clean_env.setenv("CROWDSEC_LAPI_KEY", "myapikey")
         cfg = Config.from_env()
         assert cfg.lapi_key == "myapikey"
+
+    def test_lapi_tls_paths_loaded(self, clean_env):
+        clean_env.setenv("CROWDSEC_LAPI_CA_CERT_PATH", "/certs/ca.pem")
+        clean_env.setenv("CROWDSEC_LAPI_CERT_PATH", "/certs/client.pem")
+        clean_env.setenv("CROWDSEC_LAPI_KEY_PATH", "/certs/client-key.pem")
+        cfg = Config.from_env()
+        assert cfg.lapi_ca_cert_path == "/certs/ca.pem"
+        assert cfg.lapi_cert_path == "/certs/client.pem"
+        assert cfg.lapi_key_path == "/certs/client-key.pem"
 
     def test_machine_credentials(self, clean_env):
         clean_env.setenv("CROWDSEC_MACHINE_ID", "myid")
@@ -756,6 +766,136 @@ class TestCrowdSecLAPIHealthCheck:
         import requests
         session_mock.get.side_effect = requests.RequestException("timeout")
         assert lapi.health_check() is False
+
+
+class TestCrowdSecLAPITLS:
+    def test_tls_configures_session_cert_and_ca(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="ignored",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            cert_path="/certs/client.pem",
+            key_path="/certs/client-key.pem",
+        )
+        assert lapi_tls.tls_enabled is True
+        assert lapi_tls.session.cert == ("/certs/client.pem", "/certs/client-key.pem")
+        assert lapi_tls.session.verify == "/certs/ca.pem"
+        assert "X-Api-Key" not in lapi_tls.bouncer_headers
+
+    def test_ca_path_only_verifies_server_without_mtls(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="key",
+            machine_id="machine",
+            machine_password="password",
+            logger=logger,
+            ca_cert_path="/certs/crowdsec_lapi.pem",
+        )
+        assert lapi_tls.tls_enabled is False
+        assert lapi_tls.session.verify == "/certs/crowdsec_lapi.pem"
+        assert lapi_tls.bouncer_headers["X-Api-Key"] == "key"
+
+    def test_tls_can_write_without_machine_credentials(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            cert_path="/certs/client.pem",
+            key_path="/certs/client-key.pem",
+        )
+        assert lapi_tls.can_write() is True
+
+    def test_tls_machine_login_can_use_cert_only_payload(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            cert_path="/certs/client.pem",
+            key_path="/certs/client-key.pem",
+        )
+        lapi_tls.session = MagicMock()
+        lapi_tls.session.post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={
+                "token": "tls-jwt",
+                "expire": "2099-01-01T00:00:00Z",
+            }),
+        )
+
+        headers = lapi_tls._get_machine_headers()
+
+        assert headers is not None
+        assert headers["Authorization"] == "Bearer tls-jwt"
+        login_payload = lapi_tls.session.post.call_args.kwargs["json"]
+        assert login_payload == {"scenarios": ["external/blocklist"]}
+
+    def test_tls_machine_login_includes_credentials_when_configured(self, logger):
+        lapi_tls = CrowdSecLAPI(
+            base_url="https://localhost:8080",
+            api_key="",
+            machine_id="blocklist-import",
+            machine_password="secret",
+            logger=logger,
+            ca_cert_path="/certs/ca.pem",
+            cert_path="/certs/client.pem",
+            key_path="/certs/client-key.pem",
+        )
+        lapi_tls.session = MagicMock()
+        lapi_tls.session.post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={
+                "token": "tls-jwt",
+                "expire": "2099-01-01T00:00:00Z",
+            }),
+        )
+
+        headers = lapi_tls._get_machine_headers()
+
+        assert headers is not None
+        assert headers["Authorization"] == "Bearer tls-jwt"
+        login_payload = lapi_tls.session.post.call_args.kwargs["json"]
+        assert login_payload == {
+            "machine_id": "blocklist-import",
+            "password": "secret",
+            "scenarios": ["external/blocklist"],
+        }
+
+    def test_non_tls_keeps_api_key_header(self, lapi):
+        assert lapi.tls_enabled is False
+        assert lapi.bouncer_headers["X-Api-Key"] == "testkey"
+
+    def test_validate_lapi_tls_paths_requires_cert_key_pair(self):
+        errors = validate_lapi_tls_paths(cert_path="/certs/client.pem")
+        assert any("must both be set" in error for error in errors)
+
+    def test_validate_lapi_tls_paths_accepts_existing_files(self, tmp_path):
+        ca = tmp_path / "ca.pem"
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "client-key.pem"
+        for path in (ca, cert, key):
+            path.write_text("test")
+        assert validate_lapi_tls_paths(str(ca), str(cert), str(key)) == []
+
+    def test_validate_lapi_tls_paths_allows_ca_only(self, tmp_path):
+        ca = tmp_path / "ca.pem"
+        ca.write_text("test")
+        assert validate_lapi_tls_paths(ca_cert_path=str(ca)) == []
+
+    def test_validate_lapi_tls_paths_accepts_cert_key_without_ca(self, tmp_path):
+        cert = tmp_path / "client.pem"
+        key = tmp_path / "client-key.pem"
+        for path in (cert, key):
+            path.write_text("test")
+        assert validate_lapi_tls_paths(cert_path=str(cert), key_path=str(key)) == []
 
 
 class TestCrowdSecLAPIGetExistingIPs:


### PR DESCRIPTION
Adds independent TLS options for CrowdSec LAPI clients:

- `CROWDSEC_LAPI_CA_CERT_PATH` verifies the HTTPS server certificate served by LAPI.
- `CROWDSEC_LAPI_AGENT_CERT_PATH` and `CROWDSEC_LAPI_AGENT_KEY_PATH` enable optional agent client certificate authentication for watcher login/JWT write paths.
- `CROWDSEC_LAPI_BOUNCER_CERT_PATH` and `CROWDSEC_LAPI_BOUNCER_KEY_PATH` enable optional bouncer client certificate authentication for decision reads.

This matches CrowdSec's separate auth middleware roles: agent/JWT auth for writes such as `/v1/alerts`, and bouncer auth for reads such as `/v1/decisions`. Existing API key and machine password authentication continue to work when client certificate pairs are not configured.

Follow-up implementation was based on testing and feedback from @mannp's `mtls-read-patch` branch, with separate sessions for agent and bouncer mTLS plus docs/tests updates.

Refs: https://github.com/wolffcatskyy/crowdsec-blocklist-import/issues/78