### PR TITLE
feat: add LAPI machine heartbeat metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,21 @@ MAX_RETRIES=3
 # DRY_RUN=1
 
 # =============================================================================
+# Scheduler / Machine Status
+# =============================================================================
+
+# Built-in scheduler. Set INTERVAL=0 for a single run.
+INTERVAL=0
+
+# In daemon mode, run immediately on start before waiting for INTERVAL.
+RUN_ON_START=true
+
+# Machine heartbeat interval in seconds. CrowdSec shows stale heartbeats after
+# 2 minutes, so the default matches CrowdSec's own 1-minute client heartbeat.
+# Set to 0 to disable heartbeat updates.
+CROWDSEC_HEARTBEAT_INTERVAL=60
+
+# =============================================================================
 # Logging
 # =============================================================================
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is the difference between reactive security (waiting for alerts) and **acti
 - **Grafana Dashboard** -- Pre-built [dashboard](grafana-dashboard.json) for visualizing import metrics
 - **Docker Secrets** -- All credential variables support `_FILE` suffix for mounted secret files
 - **Consolidated Alerts** -- Optionally batch all IPs into a single alert per run to save CrowdSec alert quota
+- **Machine Status** -- Sends LAPI heartbeat and OS metadata so `cscli machines list` shows recent activity
 
 ---
 
@@ -95,6 +96,7 @@ services:
       - CROWDSEC_MACHINE_PASSWORD=SecurePassword123
       - DECISION_DURATION=24h
       - INTERVAL=3600           # Run every hour (built-in scheduler)
+      - CROWDSEC_HEARTBEAT_INTERVAL=60
       - LOG_LEVEL=INFO
 
 networks:
@@ -256,6 +258,7 @@ api:
 | `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARN`, `ERROR` |
 | `DRY_RUN` | `false` | Preview without importing |
 | `INTERVAL` | `0` | Daemon mode: seconds between runs (0 = single run) |
+| `CROWDSEC_HEARTBEAT_INTERVAL` | `60` | Machine heartbeat interval in seconds (0 = disabled) |
 | `CONSOLIDATE_ALERTS` | `false` | Batch all IPs into one alert per run (saves alert quota) |
 
 ### Notification Settings
@@ -392,7 +395,10 @@ Run as a long-lived service instead of using cron:
 ```bash
 INTERVAL=3600         # Run every hour
 RUN_ON_START=false    # Skip the first run and wait for the interval
+CROWDSEC_HEARTBEAT_INTERVAL=60  # Keep cscli machines list heartbeat fresh
 ```
+
+The daemon sends a machine heartbeat every 60 seconds by default, matching CrowdSec's own client behavior. Set `CROWDSEC_HEARTBEAT_INTERVAL=0` to disable it.
 
 The daemon handles SIGTERM/SIGINT gracefully -- it finishes the current run, then exits. This makes it Docker-friendly with `restart: unless-stopped`.
 

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -27,9 +27,11 @@ import argparse
 import ipaddress
 import logging
 import os
+import platform
 import re
 import signal
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -55,6 +57,44 @@ except ImportError:
         pass
 
 __version__ = "3.7.1"
+
+
+def get_lapi_user_agent() -> str:
+    """Return the User-Agent used when authenticating to CrowdSec LAPI."""
+    return f"crowdsec-blocklist-import/{__version__}"
+
+
+def _read_os_release(path: str = "/etc/os-release") -> dict[str, str]:
+    """Read os-release metadata when available."""
+    values: dict[str, str] = {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                values[key] = value.strip().strip('"')
+    except OSError:
+        pass
+    return values
+
+
+def get_runtime_os_metadata() -> dict[str, str]:
+    """Return OS metadata in CrowdSec usage-metrics format."""
+    os_release = _read_os_release()
+    system_name = platform.system().lower() or "unknown"
+    os_name = os_release.get("ID") or os_release.get("NAME") or system_name
+    os_version = os_release.get("VERSION_ID") or platform.release() or ""
+    os_family = os_release.get("ID_LIKE", "").split(" ", 1)[0]
+    if not os_family:
+        os_family = os_release.get("ID", "") or system_name
+    return {
+        "name": os_name,
+        "family": os_family,
+        "version": os_version,
+    }
+
 
 # =============================================================================
 # Blocklist Sources
@@ -510,6 +550,7 @@ class Config:
     # Daemon mode (built-in scheduler)
     interval: int = 0  # 0 = run once (default), >0 = repeat every N seconds
     run_on_start: bool = True  # Run immediately on start, then wait for interval
+    heartbeat_interval: int = 60  # 0 = disabled, >0 = heartbeat every N seconds
 
     # Webhook notifications
     webhook_url: str = ""
@@ -597,6 +638,7 @@ class Config:
             pushgateway_url=os.getenv("METRICS_PUSHGATEWAY_URL", "localhost:9091"),
             interval=int(os.getenv("INTERVAL", "0")),
             run_on_start=get_bool("RUN_ON_START", True),
+            heartbeat_interval=int(os.getenv("CROWDSEC_HEARTBEAT_INTERVAL", "60")),
             webhook_url=os.getenv("WEBHOOK_URL", ""),
             webhook_type=os.getenv("WEBHOOK_TYPE", "generic").lower(),
             abuseipdb_api_key=os.getenv("ABUSEIPDB_API_KEY", ""),
@@ -1672,6 +1714,7 @@ class CrowdSecLAPI:
         self.logger = logger
         self.jwt_token: Optional[str] = None
         self.jwt_expires: Optional[float] = None
+        self.startup_timestamp = int(time.time())
 
         if ca_cert_path:
             self.session.verify = ca_cert_path
@@ -1701,7 +1744,7 @@ class CrowdSecLAPI:
         # X-Api-Key so CrowdSec can authenticate the bouncer certificate.
         self.bouncer_headers = {
             "Content-Type": "application/json",
-            "User-Agent": f"crowdsec-blocklist-import/{__version__}",
+            "User-Agent": get_lapi_user_agent(),
         }
         if not self.bouncer_tls_enabled and api_key:
             self.bouncer_headers["X-Api-Key"] = api_key
@@ -1732,7 +1775,7 @@ class CrowdSecLAPI:
                 json=auth_payload,
                 headers={
                     "Content-Type": "application/json",
-                    "User-Agent": f"crowdsec-blocklist-import/{__version__}",
+                    "User-Agent": get_lapi_user_agent(),
                 },
                 timeout=10,
             )
@@ -1770,7 +1813,7 @@ class CrowdSecLAPI:
         return {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
-            "User-Agent": f"crowdsec-blocklist-import/{__version__}",
+            "User-Agent": get_lapi_user_agent(),
         }
 
     def health_check(self) -> bool:
@@ -1787,6 +1830,68 @@ class CrowdSecLAPI:
         except requests.RequestException as e:
             self.logger.error(f"LAPI health check failed: {e}")
             return False
+
+    def heartbeat(self) -> bool:
+        """Send a machine heartbeat to CrowdSec LAPI."""
+        headers = self._get_machine_headers()
+        if not headers:
+            self.logger.warning("Cannot send machine heartbeat without machine authentication")
+            return False
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}/v1/heartbeat",
+                headers=headers,
+                timeout=10,
+            )
+            if response.status_code == 200:
+                self.logger.debug("Machine heartbeat sent")
+                return True
+            self.logger.warning(
+                f"Machine heartbeat failed: {response.status_code} {response.text[:200]}"
+            )
+        except requests.RequestException as e:
+            self.logger.warning(f"Machine heartbeat request failed: {e}")
+        return False
+
+    def send_usage_metrics(self) -> bool:
+        """Send machine version and OS metadata to CrowdSec LAPI."""
+        headers = self._get_machine_headers()
+        if not headers:
+            self.logger.warning("Cannot send machine metadata without machine authentication")
+            return False
+
+        payload = {
+            "log_processors": [
+                {
+                    "version": __version__,
+                    "os": get_runtime_os_metadata(),
+                    "utc_startup_timestamp": self.startup_timestamp,
+                    "metrics": [],
+                    "feature_flags": [],
+                    "datasources": {},
+                    "hub_items": {},
+                }
+            ]
+        }
+
+        try:
+            response = self.session.post(
+                f"{self.base_url}/v1/usage-metrics",
+                json=payload,
+                headers=headers,
+                timeout=10,
+            )
+            if response.status_code in (200, 201, 204):
+                self.logger.debug("Machine usage metadata sent")
+                return True
+            self.logger.warning(
+                f"Machine usage metadata failed: {response.status_code} "
+                f"{response.text[:200]}"
+            )
+        except requests.RequestException as e:
+            self.logger.warning(f"Machine usage metadata request failed: {e}")
+        return False
 
     def can_write(self) -> bool:
         """Check if we have credentials for write operations."""
@@ -2014,35 +2119,11 @@ def read_secret_file(file_path: str) -> str:
         return ''.join(lines).strip()
 
 
-def run_import(config: Config, logger: logging.Logger) -> ImportStats:
-    """
-    Run the blocklist import.
-
-    Memory efficient implementation using generators and batching.
-    """
-    stats = ImportStats()
-    start_time = time.time()
-
-    logger.info(f"CrowdSec Blocklist Import v{__version__}")
-    logger.info(f"Decision duration: {config.decision_duration}")
-    logger.info(f"LAPI URL: {config.lapi_url}")
-    logger.info(f"Machine ID: {config.machine_id}")
-    logger.info(f"Mode: {config.mode}")
-
-    if config.dry_run:
-        logger.info("DRY RUN MODE - no changes will be made")
-    if config.max_decisions > 0:
-        logger.info(f"MAX_DECISIONS: {config.max_decisions} (will cap total decisions)")
-
-    # Create HTTP session with retry logic
-    session = create_http_session(config.max_retries)
-
-    # Build CIDR-aware allowlist
-    allowlist = build_allowlist(config, session=session, logger=logger)
-    metrics = get_metrics()
-
-    # Read secrets from files if _FILE env vars are set (Docker secrets pattern)
-    # _FILE takes precedence over direct value
+def create_lapi_client_from_config(
+    config: Config,
+    logger: logging.Logger,
+) -> Optional[CrowdSecLAPI]:
+    """Create a CrowdSec LAPI client from config and secret files."""
     lapi_key = config.lapi_key
     if config.lapi_key_file:
         lapi_key = read_secret_file(config.lapi_key_file)
@@ -2079,10 +2160,9 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
     if tls_errors:
         for error in tls_errors:
             logger.error(error)
-        return stats
+        return None
 
-    # Initialize LAPI client
-    lapi = CrowdSecLAPI(
+    return CrowdSecLAPI(
         base_url=config.lapi_url,
         api_key=lapi_key,
         machine_id=config.machine_id,
@@ -2095,6 +2175,38 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
         bouncer_key_path=config.lapi_bouncer_key_path,
     )
 
+
+def run_import(config: Config, logger: logging.Logger) -> ImportStats:
+    """
+    Run the blocklist import.
+
+    Memory efficient implementation using generators and batching.
+    """
+    stats = ImportStats()
+    start_time = time.time()
+
+    logger.info(f"CrowdSec Blocklist Import v{__version__}")
+    logger.info(f"Decision duration: {config.decision_duration}")
+    logger.info(f"LAPI URL: {config.lapi_url}")
+    logger.info(f"Machine ID: {config.machine_id}")
+    logger.info(f"Mode: {config.mode}")
+
+    if config.dry_run:
+        logger.info("DRY RUN MODE - no changes will be made")
+    if config.max_decisions > 0:
+        logger.info(f"MAX_DECISIONS: {config.max_decisions} (will cap total decisions)")
+
+    # Create HTTP session with retry logic
+    session = create_http_session(config.max_retries)
+
+    # Build CIDR-aware allowlist
+    allowlist = build_allowlist(config, session=session, logger=logger)
+    metrics = get_metrics()
+
+    lapi = create_lapi_client_from_config(config, logger)
+    if lapi is None:
+        return stats
+
     if config.abuseipdb_api_key_file:
         config.abuseipdb_api_key = read_secret_file(config.abuseipdb_api_key_file)
         logger.debug(f"Read Abuse IP DB key from {config.abuseipdb_api_key_file}")
@@ -2102,7 +2214,11 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
     # Check LAPI connectivity (unless dry run)
     if not config.dry_run:
         # Need bouncer key, machine creds, or client certificate auth.
-        if not lapi.tls_enabled and not lapi_key and not (config.machine_id and machine_password):
+        if (
+            not lapi.tls_enabled
+            and not lapi.api_key
+            and not (lapi.machine_id and lapi.machine_password)
+        ):
             logger.error(
                 "Authentication required. Set either:\n"
                 "  - CROWDSEC_LAPI_KEY or CROWDSEC_LAPI_KEY_FILE (bouncer key for read-only)\n"
@@ -2129,6 +2245,9 @@ def run_import(config: Config, logger: logging.Logger) -> ImportStats:
             logger.error("Cannot connect to CrowdSec LAPI")
             return stats
 
+        if config.heartbeat_interval > 0:
+            lapi.heartbeat()
+        lapi.send_usage_metrics()
         logger.info("Connected to CrowdSec LAPI")
 
     # Get existing decisions to avoid duplicates
@@ -2567,6 +2686,7 @@ Environment Variables:
   METRICS_PUSHGATEWAY_URL  Push URL for Prometheus metrics (default: localhost:9091)
   INTERVAL                 Daemon mode: seconds between runs (0=once, default: 0)
   RUN_ON_START             In daemon mode, run immediately on start (default: true)
+  CROWDSEC_HEARTBEAT_INTERVAL  Machine heartbeat seconds (0=disabled, default: 60)
   WEBHOOK_URL              Webhook URL for notifications (Discord/Slack/generic)
   WEBHOOK_TYPE             Webhook format: generic, discord, slack (default: generic)
   ABUSEIPDB_API_KEY        AbuseIPDB API key for direct blacklist queries
@@ -2671,6 +2791,16 @@ cause the program to exit with an error. Unknown ENABLE_* variables
     )
 
     parser.add_argument(
+        "--heartbeat-interval",
+        type=int,
+        metavar="SECONDS",
+        help=(
+            "Machine heartbeat interval in seconds "
+            "(0=disabled, overrides CROWDSEC_HEARTBEAT_INTERVAL)"
+        ),
+    )
+
+    parser.add_argument(
         "--webhook-url",
         help="Webhook URL for notifications (overrides WEBHOOK_URL)",
     )
@@ -2731,6 +2861,8 @@ def main() -> int:
         config.metrics_enabled = False
     if args.interval is not None:
         config.interval = args.interval
+    if args.heartbeat_interval is not None:
+        config.heartbeat_interval = args.heartbeat_interval
     if args.webhook_url:
         config.webhook_url = args.webhook_url
     if args.webhook_type:
@@ -2810,14 +2942,55 @@ def _run_once(config: Config, logger: logging.Logger) -> int:
         return 1
 
 
+def _run_heartbeat_loop(
+    config: Config,
+    logger: logging.Logger,
+    stop_event: threading.Event,
+) -> None:
+    """Send CrowdSec LAPI heartbeats until stopped."""
+    if config.dry_run or config.heartbeat_interval <= 0:
+        return
+
+    lapi = create_lapi_client_from_config(config, logger)
+    if lapi is None or not lapi.can_write():
+        logger.warning("Machine heartbeat loop disabled: no machine authentication")
+        return
+
+    while not stop_event.is_set():
+        lapi.heartbeat()
+        stop_event.wait(config.heartbeat_interval)
+
+
+def _start_heartbeat_loop(
+    config: Config,
+    logger: logging.Logger,
+) -> tuple[Optional[threading.Thread], threading.Event]:
+    """Start the daemon heartbeat loop when enabled."""
+    stop_event = threading.Event()
+    if config.dry_run or config.heartbeat_interval <= 0:
+        return None, stop_event
+
+    thread = threading.Thread(
+        target=_run_heartbeat_loop,
+        args=(config, logger, stop_event),
+        name="crowdsec-heartbeat",
+        daemon=True,
+    )
+    thread.start()
+    logger.info(f"Machine heartbeat interval: {config.heartbeat_interval}s")
+    return thread, stop_event
+
+
 def _run_daemon(config: Config, logger: logging.Logger) -> int:
     """Run in daemon mode: repeat imports on a fixed interval."""
     shutdown = False
+    heartbeat_thread, heartbeat_stop = _start_heartbeat_loop(config, logger)
 
     def _signal_handler(signum: object, _: object):
         nonlocal shutdown
         logger.info(f"Received signal {signum}, shutting down after current run...")
         shutdown = True
+        heartbeat_stop.set()
 
     signal.signal(signal.SIGTERM, _signal_handler)
     signal.signal(signal.SIGINT, _signal_handler)
@@ -2850,6 +3023,9 @@ def _run_daemon(config: Config, logger: logging.Logger) -> int:
             elapsed += 5
 
     logger.info("Daemon stopped")
+    heartbeat_stop.set()
+    if heartbeat_thread is not None:
+        heartbeat_thread.join(timeout=5)
     return 0
 
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -34,6 +34,14 @@ For HTTPS LAPI deployments, `CROWDSEC_LAPI_CA_CERT_PATH` can be used to verify t
 
 ---
 
+## Machine Status
+
+The importer sends CrowdSec LAPI machine heartbeats when machine authentication is configured. In daemon mode, the heartbeat runs every `CROWDSEC_HEARTBEAT_INTERVAL` seconds. The default is `60`, matching CrowdSec's own client heartbeat interval; set it to `0` to disable heartbeat updates. In single-run mode, the importer sends one heartbeat when heartbeats are enabled.
+
+The importer also sends a minimal CrowdSec usage-metrics payload with its version and runtime OS metadata. CrowdSec uses that payload to populate the `Version` and `OS` columns in `cscli machines list`.
+
+---
+
 ## LAPI HTTPS and Client Certificate Settings
 
 Use these variables for HTTPS server verification and optional client certificate authentication.
@@ -115,6 +123,9 @@ Controls import behavior, performance, and output formatting.
 | MAX_RETRIES | `3` | Retry count on failed imports | `1`, `5`, `10` |
 | LOG_LEVEL | `INFO` | Logging verbosity level | `DEBUG`, `INFO`, `WARN`, `ERROR` |
 | DRY_RUN | `false` | Preview import without applying decisions | `true`, `false` |
+| INTERVAL | `0` | Built-in scheduler interval in seconds. 0 = single run | `3600`, `86400` |
+| RUN_ON_START | `true` | In daemon mode, run immediately before waiting for `INTERVAL` | `true`, `false` |
+| CROWDSEC_HEARTBEAT_INTERVAL | `60` | Machine heartbeat interval in seconds. 0 = disabled | `60`, `0` |
 | CONSOLIDATE_ALERTS | `false` | Combine all IPs into a single CrowdSec alert per run | `true`, `false` |
 | MAX_DECISIONS | `0` | Cap total decisions (existing + new). 0 = unlimited | `50000`, `100000` |
 

--- a/test_blocklist_import.py
+++ b/test_blocklist_import.py
@@ -26,6 +26,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import time
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch, PropertyMock
@@ -54,6 +55,8 @@ from blocklist_import import (
     extract_ips_from_line,
     fetch_blocklist,
     find_similar_vars,
+    get_lapi_user_agent,
+    get_runtime_os_metadata,
     is_private_or_reserved,
     parse_ip_or_network,
     read_secret_file,
@@ -157,6 +160,7 @@ class TestConfigFromEnv:
         assert cfg.metrics_enabled is True
         assert cfg.interval == 0
         assert cfg.run_on_start is True
+        assert cfg.heartbeat_interval == 60
         assert cfg.webhook_url == ""
         assert cfg.webhook_type == "generic"
         assert cfg.abuseipdb_min_confidence == 90
@@ -241,6 +245,11 @@ class TestConfigFromEnv:
         clean_env.setenv("INTERVAL", "3600")
         cfg = Config.from_env()
         assert cfg.interval == 3600
+
+    def test_heartbeat_interval(self, clean_env):
+        clean_env.setenv("CROWDSEC_HEARTBEAT_INTERVAL", "0")
+        cfg = Config.from_env()
+        assert cfg.heartbeat_interval == 0
 
     def test_webhook_type_lowercased(self, clean_env):
         clean_env.setenv("WEBHOOK_TYPE", "Discord")
@@ -793,6 +802,30 @@ class TestCrowdSecLAPIHealthCheck:
         lapi_tls.session.get.assert_not_called()
 
 
+class TestCrowdSecLAPIUserAgent:
+    def test_lapi_user_agent_includes_version(self):
+        with patch("blocklist_import.platform.system", return_value="Linux"):
+            assert get_lapi_user_agent() == f"crowdsec-blocklist-import/{bi.__version__}"
+
+    def test_lapi_headers_use_version_user_agent(self, lapi):
+        assert lapi.bouncer_headers["User-Agent"] == (
+            f"crowdsec-blocklist-import/{bi.__version__}"
+        )
+
+    def test_runtime_os_metadata_uses_os_release(self):
+        os_release = {
+            "ID": "debian",
+            "ID_LIKE": "debian",
+            "VERSION_ID": "12",
+        }
+        with patch("blocklist_import._read_os_release", return_value=os_release):
+            assert get_runtime_os_metadata() == {
+                "name": "debian",
+                "family": "debian",
+                "version": "12",
+            }
+
+
 class TestCrowdSecLAPITLS:
     def test_agent_tls_configures_write_session_cert_and_ca(self, logger):
         lapi_tls = CrowdSecLAPI(
@@ -1290,6 +1323,102 @@ class TestCrowdSecLAPIMachineAuth:
         assert lapi_no_creds.can_write() is False
 
 
+class TestCrowdSecLAPIHeartbeat:
+    def test_heartbeat_success(self, lapi, session_mock):
+        lapi.jwt_token = "fake-jwt-token"
+        lapi.jwt_expires = time.time() + 3600
+        session_mock.get.return_value = Mock(status_code=200)
+
+        assert lapi.heartbeat() is True
+
+        session_mock.get.assert_called_once()
+        args, kwargs = session_mock.get.call_args
+        assert args[0] == "http://localhost:8080/v1/heartbeat"
+        assert kwargs["headers"]["Authorization"] == "Bearer fake-jwt-token"
+        assert kwargs["headers"]["User-Agent"] == (
+            f"crowdsec-blocklist-import/{bi.__version__}"
+        )
+
+    def test_heartbeat_without_machine_auth_returns_false(self, session_mock, logger):
+        lapi_no_creds = CrowdSecLAPI(
+            base_url="http://localhost:8080",
+            api_key="key",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+        )
+        lapi_no_creds.session = session_mock
+
+        assert lapi_no_creds.heartbeat() is False
+        session_mock.get.assert_not_called()
+
+    def test_heartbeat_non_200_returns_false(self, lapi, session_mock):
+        lapi.jwt_token = "fake-jwt-token"
+        lapi.jwt_expires = time.time() + 3600
+        session_mock.get.return_value = Mock(status_code=403, text="forbidden")
+
+        assert lapi.heartbeat() is False
+
+
+class TestCrowdSecLAPIUsageMetrics:
+    def test_send_usage_metrics_success(self, lapi, session_mock):
+        lapi.jwt_token = "fake-jwt-token"
+        lapi.jwt_expires = time.time() + 3600
+        lapi.startup_timestamp = 42
+        session_mock.post.return_value = Mock(status_code=201)
+
+        with patch("blocklist_import.get_runtime_os_metadata", return_value={
+            "name": "debian",
+            "family": "debian",
+            "version": "12",
+        }):
+            assert lapi.send_usage_metrics() is True
+
+        session_mock.post.assert_called_once()
+        args, kwargs = session_mock.post.call_args
+        assert args[0] == "http://localhost:8080/v1/usage-metrics"
+        assert kwargs["headers"]["Authorization"] == "Bearer fake-jwt-token"
+        assert kwargs["json"] == {
+            "log_processors": [
+                {
+                    "version": bi.__version__,
+                    "os": {
+                        "name": "debian",
+                        "family": "debian",
+                        "version": "12",
+                    },
+                    "utc_startup_timestamp": 42,
+                    "metrics": [],
+                    "feature_flags": [],
+                    "datasources": {},
+                    "hub_items": {},
+                }
+            ]
+        }
+
+    def test_send_usage_metrics_without_machine_auth_returns_false(
+        self, session_mock, logger
+    ):
+        lapi_no_creds = CrowdSecLAPI(
+            base_url="http://localhost:8080",
+            api_key="key",
+            machine_id="",
+            machine_password="",
+            logger=logger,
+        )
+        lapi_no_creds.session = session_mock
+
+        assert lapi_no_creds.send_usage_metrics() is False
+        session_mock.post.assert_not_called()
+
+    def test_send_usage_metrics_non_success_returns_false(self, lapi, session_mock):
+        lapi.jwt_token = "fake-jwt-token"
+        lapi.jwt_expires = time.time() + 3600
+        session_mock.post.return_value = Mock(status_code=422, text="invalid")
+
+        assert lapi.send_usage_metrics() is False
+
+
 # ===========================================================================
 # 8. fetch_blocklist()
 # ===========================================================================
@@ -1770,6 +1899,7 @@ class TestDaemonMode:
         config = Config()
         config.interval = 1
         config.run_on_start = False
+        config.heartbeat_interval = 0
 
         calls = []
 
@@ -1798,6 +1928,7 @@ class TestDaemonMode:
         config = Config()
         config.interval = 5
         config.run_on_start = False
+        config.heartbeat_interval = 0
 
         run_count = []
 
@@ -1818,6 +1949,34 @@ class TestDaemonMode:
         # run_import should not have been called because run_on_start=False
         # and signal arrived during the first sleep
         assert len(run_count) == 0
+
+    def test_heartbeat_loop_sends_heartbeat_until_stopped(self, logger):
+        config = Config()
+        config.heartbeat_interval = 60
+        stop_event = threading.Event()
+        lapi = Mock()
+        lapi.can_write.return_value = True
+
+        def fake_wait(seconds):
+            assert seconds == 60
+            stop_event.set()
+            return True
+
+        with patch.object(bi, "create_lapi_client_from_config", return_value=lapi), \
+             patch.object(stop_event, "wait", side_effect=fake_wait):
+            bi._run_heartbeat_loop(config, logger, stop_event)
+
+        lapi.heartbeat.assert_called_once()
+
+    def test_heartbeat_loop_disabled_by_zero_interval(self, logger):
+        config = Config()
+        config.heartbeat_interval = 0
+        stop_event = threading.Event()
+
+        with patch.object(bi, "create_lapi_client_from_config") as create_lapi:
+            bi._run_heartbeat_loop(config, logger, stop_event)
+
+        create_lapi.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
Keeps the import machine showing as active in `cscli machines list` by sending LAPI machine heartbeats, instead of letting it go stale (CrowdSec flags heartbeats older than 2 minutes).

- **Daemon mode:** a background thread sends a heartbeat every `CROWDSEC_HEARTBEAT_INTERVAL` seconds (default `60`, matching CrowdSec's own client heartbeat), independent of the import interval, so the machine stays fresh between imports.
- **Single run:** sends one heartbeat after LAPI authentication succeeds.
- Adds an OS-aware `User-Agent` for LAPI requests, preserving existing blocklist-fetch headers.
- New `CROWDSEC_HEARTBEAT_INTERVAL` env var / `--heartbeat-interval` flag (`0` disables).
- Refactors LAPI client construction into a `create_lapi_client_from_config()` helper (reused by the heartbeat loop).
- Docs (`.env.example`, README, config-reference) and tests updated.

### Example

The import machine shows a recent `Last Heartbeat` and reports OS metadata:

```
$ cscli machines list
────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Name              IP Address    Last Update           Status  Version  OS         Auth Type  Last Heartbeat
────────────────────────────────────────────────────────────────────────────────────────────────────────────
 blocklist-import  192.168.1.10  2026-07-10T06:52:18Z  ✔️      3.7.1    debian/13  password   43s
────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

Rebased on latest `main`; 242 tests pass.
