### PR TITLE
feat: granular Firehol level control (ENABLE_FIREHOL_LEVEL1/2/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,8 +113,16 @@ ENABLE_SPAMHAUS=true
 # Blocklist.de (all/ssh/apache/mail)
 ENABLE_BLOCKLIST_DE=true
 
-# Firehol level1 and level2
+# Firehol level1/2/3 (master switch)
 ENABLE_FIREHOL=true
+# Optional per-level overrides. Each defaults to ENABLE_FIREHOL when unset.
+# Set individually to enable just specific Firehol levels, e.g.:
+#   ENABLE_FIREHOL=false
+#   ENABLE_FIREHOL_LEVEL1=true
+#   ENABLE_FIREHOL_LEVEL2=true
+ENABLE_FIREHOL_LEVEL1=true
+ENABLE_FIREHOL_LEVEL2=true
+ENABLE_FIREHOL_LEVEL3=true
 
 # Abuse.ch (Feodo, URLhaus)
 ENABLE_ABUSE_CH=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 
+### Added
+
+- **Granular Firehol Level Control** — `ENABLE_FIREHOL` remains the master switch for all three Firehol levels, but you can now enable/disable individual levels with `ENABLE_FIREHOL_LEVEL1`, `ENABLE_FIREHOL_LEVEL2`, and `ENABLE_FIREHOL_LEVEL3`. Each level flag falls back to the master `ENABLE_FIREHOL` when unset, so existing configs are unchanged. Closes [#83](https://github.com/wolffcatskyy/crowdsec-blocklist-import/issues/83)
+
 ---
 
 ## [3.7.0] — 2026-03-13

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -182,12 +182,12 @@ BLOCKLIST_SOURCES: list[BlocklistSource] = [
     BlocklistSource(
         name="Firehol level1",
         url="https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset",
-        enabled_key="enable_firehol",
+        enabled_key="enable_firehol_level1",
     ),
     BlocklistSource(
         name="Firehol level2",
         url="https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level2.netset",
-        enabled_key="enable_firehol",
+        enabled_key="enable_firehol_level2",
     ),
     # Abuse.ch
     BlocklistSource(
@@ -303,7 +303,7 @@ BLOCKLIST_SOURCES: list[BlocklistSource] = [
     BlocklistSource(
         name="Firehol level3",
         url="https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level3.netset",
-        enabled_key="enable_firehol",
+        enabled_key="enable_firehol_level3",
     ),
     # Maltrail mass scanners
     BlocklistSource(
@@ -537,6 +537,9 @@ class Config:
     enable_spamhaus: bool = True
     enable_blocklist_de: bool = True
     enable_firehol: bool = True
+    enable_firehol_level1: bool = True
+    enable_firehol_level2: bool = True
+    enable_firehol_level3: bool = True
     enable_abuse_ch: bool = True
     enable_emerging_threats: bool = True
     enable_binary_defense: bool = True
@@ -562,6 +565,20 @@ class Config:
         def get_bool(key: str, default: bool = True) -> bool:
             val = os.getenv(key, str(default)).lower()
             return val in ("true", "1", "yes", "on")
+
+        def get_bool_or_none(key: str) -> Optional[bool]:
+            val = os.getenv(key)
+            if val is None:
+                return None
+            return val.lower() in ("true", "1", "yes", "on")
+
+        # Firehol master switch + optional per-level overrides.
+        # Each ENABLE_FIREHOL_LEVELn falls back to the master ENABLE_FIREHOL
+        # when unset, preserving the original all-or-nothing behaviour.
+        firehol_master = get_bool("ENABLE_FIREHOL")
+        fh_l1 = get_bool_or_none("ENABLE_FIREHOL_LEVEL1")
+        fh_l2 = get_bool_or_none("ENABLE_FIREHOL_LEVEL2")
+        fh_l3 = get_bool_or_none("ENABLE_FIREHOL_LEVEL3")
 
         return cls(
             lapi_url=os.getenv("CROWDSEC_LAPI_URL", "http://localhost:8080").rstrip("/"),
@@ -608,7 +625,10 @@ class Config:
             enable_ipsum=get_bool("ENABLE_IPSUM"),
             enable_spamhaus=get_bool("ENABLE_SPAMHAUS"),
             enable_blocklist_de=get_bool("ENABLE_BLOCKLIST_DE"),
-            enable_firehol=get_bool("ENABLE_FIREHOL"),
+            enable_firehol=firehol_master,
+            enable_firehol_level1=fh_l1 if fh_l1 is not None else firehol_master,
+            enable_firehol_level2=fh_l2 if fh_l2 is not None else firehol_master,
+            enable_firehol_level3=fh_l3 if fh_l3 is not None else firehol_master,
             enable_abuse_ch=get_bool("ENABLE_ABUSE_CH"),
             enable_emerging_threats=get_bool("ENABLE_EMERGING_THREATS"),
             enable_binary_defense=get_bool("ENABLE_BINARY_DEFENSE"),
@@ -2575,7 +2595,10 @@ Environment Variables:
   ENABLE_IPSUM             Enable IPsum blocklist (default: true)
   ENABLE_SPAMHAUS          Enable Spamhaus DROP (default: true)
   ENABLE_BLOCKLIST_DE      Enable Blocklist.de feeds (default: true)
-  ENABLE_FIREHOL           Enable Firehol levels 1/2/3 (default: true)
+  ENABLE_FIREHOL           Enable all Firehol levels 1/2/3 (master switch, default: true)
+  ENABLE_FIREHOL_LEVEL1    Enable only Firehol level1 (overrides master when set)
+  ENABLE_FIREHOL_LEVEL2    Enable only Firehol level2 (overrides master when set)
+  ENABLE_FIREHOL_LEVEL3    Enable only Firehol level3 (overrides master when set)
   ENABLE_ABUSE_CH          Enable Abuse.ch feeds (default: true)
   ... and more (see README.md)
 

--- a/test_blocklist_import.py
+++ b/test_blocklist_import.py
@@ -268,6 +268,35 @@ class TestConfigFromEnv:
             cfg = Config.from_env()
         assert cfg.consolidate_alerts is False
 
+    def test_firehol_granular_levels_default_to_master(self, clean_env, monkeypatch):
+        """All three Firehol levels follow the master ENABLE_FIREHOL when unset."""
+        with patch("blocklist_import.load_dotenv", return_value=None):
+            cfg = Config.from_env()
+        assert cfg.enable_firehol is True
+        assert cfg.enable_firehol_level1 is True
+        assert cfg.enable_firehol_level2 is True
+        assert cfg.enable_firehol_level3 is True
+
+    def test_firehol_granular_level_override(self, clean_env, monkeypatch):
+        """A per-level flag overrides the master switch for that level only."""
+        clean_env.setenv("ENABLE_FIREHOL", "false")
+        clean_env.setenv("ENABLE_FIREHOL_LEVEL1", "true")
+        clean_env.setenv("ENABLE_FIREHOL_LEVEL3", "false")
+        with patch("blocklist_import.load_dotenv", return_value=None):
+            cfg = Config.from_env()
+        assert cfg.enable_firehol is False
+        assert cfg.enable_firehol_level1 is True   # explicit override on
+        assert cfg.enable_firehol_level2 is False  # falls back to master off
+        assert cfg.enable_firehol_level3 is False  # explicit override off
+
+    def test_firehol_master_off_disables_all_when_no_overrides(self, clean_env, monkeypatch):
+        clean_env.setenv("ENABLE_FIREHOL", "false")
+        with patch("blocklist_import.load_dotenv", return_value=None):
+            cfg = Config.from_env()
+        assert cfg.enable_firehol_level1 is False
+        assert cfg.enable_firehol_level2 is False
+        assert cfg.enable_firehol_level3 is False
+
     def test_abuseipdb_settings(self, clean_env):
         clean_env.setenv("ABUSEIPDB_API_KEY", "abc123")
         clean_env.setenv("ABUSEIPDB_MIN_CONFIDENCE", "75")


### PR DESCRIPTION
## Summary

Closes #83. Previously `ENABLE_FIREHOL` was an all-or-nothing switch for all three Firehol levels. This adds per-level control:

- `ENABLE_FIREHOL_LEVEL1`, `ENABLE_FIREHOL_LEVEL2`, `ENABLE_FIREHOL_LEVEL3`
- Each level flag **falls back to the master `ENABLE_FIREHOL`** when unset, so existing configs behave identically.
- When set, a per-level flag overrides the master for that level only.

## Example: enable only level1

```ini
ENABLE_FIREHOL=false
ENABLE_FIREHOL_LEVEL1=true
```

## Implementation

- Each Firehol `BlocklistSource` now uses its own `enabled_key` (`enable_firehol_level1/2/3`).
- `Config.from_env()` computes each level from `ENABLE_FIREHOL_LEVELn` if present, else from the master `ENABLE_FIREHOL`.
- `.env.example` and the `--help` text updated; `VALID_ENABLE_VARS` picks up the new keys automatically.

## Verification

- Added 3 unit tests covering default-to-master, per-level override, and master-off behavior.
- Full suite: 228 passed, 6 skipped.
- End-to-end check confirms only the enabled level(s) are passed to the importer gate.

Backward compatible — no behavior change for users who only set `ENABLE_FIREHOL`.