### PR TITLE
Fix #89: deterministic pinned tag on release + verify it published to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,6 +41,16 @@ jobs:
           fi
           echo "Version check passed: tag=$TAG_VERSION, code=$CODE_VERSION"
 
+      - name: Compute release version tag
+        id: relver
+        if: github.event_name == 'release'
+        run: |
+          # Strip a leading "v" so the pinned image tag matches existing
+          # conventions (e.g. 3.7.1, not v3.7.1).
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -67,6 +77,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' || github.ref_name == 'main' }}
+            # Deterministic pinned tag on release, independent of ref parsing.
+            # semver patterns above only populate when the run's ref is the tag;
+            # this guarantees the versioned tag lands on every release. (#89)
+            type=raw,value=${{ steps.relver.outputs.version }},enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -80,3 +94,24 @@ jobs:
             VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || 'dev' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify pinned tag is published on registry
+        if: github.event_name == 'release'
+        run: |
+          # Guards against the silent gap in #89, where `latest` was current
+          # but the pinned version tag never made it to ghcr. Fail the release
+          # loudly instead of leaving users on a stale pinned image.
+          VERSION="${{ steps.relver.outputs.version }}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+          echo "Verifying $IMAGE is present on the registry..."
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools inspect "$IMAGE" >/dev/null 2>&1; then
+              echo "OK: $IMAGE is published."
+              exit 0
+            fi
+            echo "Attempt $attempt: $IMAGE not visible yet, retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Pinned tag $IMAGE was not found on the registry after publish."
+          echo "::error::The release did not produce a versioned image. Re-run this workflow for the release, or check the push step above."
+          exit 1


### PR DESCRIPTION
Fixes #89 — the `ghcr.io` pinned version tag lagging behind GitHub releases (`latest` was current at 3.7.1 but the newest pinned tag was 3.6.0).

## Root cause

The `docker/metadata-action` `type=semver` tags only populate when the workflow run's ref **is** the git tag. On a `release: published` event the ref is the tag, so this normally works — but if the release-triggered run failed or never fired, the only run that published anything was the `push` to `main`, which emits just the `latest` tag (and branch tags), never a versioned/pinned tag. That's exactly the observed symptom: `latest` current, pinned stale.

## Fix

1. **Deterministic pinned tag on release.** A new `Compute release version tag` step strips the leading `v` from `release.tag_name`, and a `type=raw,value=${{ steps.relver.outputs.version }},enable=${{ github.event_name == 'release' }}` entry guarantees the versioned tag is applied on every release regardless of ref parsing.
2. **Fail loudly if it didn't land.** A new post-push `Verify pinned tag is published on registry` step runs `docker buildx imagetools inspect` against the pinned tag (with a few retries) and fails the release if the tag isn't visible on ghcr — so a silent gap like #89 can't recur unnoticed.

YAML validated. Note: this prevents recurrence; getting **3.7.1** onto ghcr right now still requires re-running the release publish for `v3.7.1`, which I'm handling separately.
