### PR TITLE
Fix CHANGELOG v3.7.1 date: 2026-04-20 → 2026-03-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to crowdsec-blocklist-import are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
 ---
-## [3.7.1] — 2026-04-20
+## [3.7.1] — 2026-03-25
 
 ### Fixed
 


### PR DESCRIPTION
The CHANGELOG entry for v3.7.1 showed 2026-04-20 as the release date, but the tag and release artifact were created on 2026-03-25. This corrects the date to match the actual release.