### PR TITLE
docs: restore author credit + add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+# Contributors
+
+crowdsec-blocklist-import is maintained by **@wolffcatskyy** (original author).
+
+## Key contributors
+
+- **@wolffcatskyy** — creator, maintainer, architecture, releases
+- **@gaelj** — major contributor (Feb–Mar 2026): `BlocklistSource` standardization/refactor (#59),
+  CI release automation (#71), reliability fixes (429 handling #53, LAPI retries #68, IP refresh #72),
+  Sentinel Turris source (#55), AbuseIPDB key-file support (#50), Grafana dashboards (#43/#54),
+  allow-lists (#27), and more.
+
+Thanks to everyone who has filed issues, tested, and contributed feedback.

--- a/blocklist_import.py
+++ b/blocklist_import.py
@@ -16,7 +16,8 @@ Features:
 
 Authors:
 
-- @gaelj
+- @wolffcatskyy (original author & maintainer)
+- @gaelj (key contributor: BlocklistSource refactor, CI, reliability fixes)
 
 License: MIT
 """


### PR DESCRIPTION
Fixes the file Authors header that listed only @gaelj, and adds a CONTRIBUTORS.md crediting both @wolffcatskyy (original author/maintainer) and @gaelj (key contributor). No code changes.